### PR TITLE
feat: Enable the NodeJS Client Queue API to specify the Queue Name (#258)

### DIFF
--- a/packages/nodejs-client/index.js
+++ b/packages/nodejs-client/index.js
@@ -15,13 +15,14 @@ const fetch = globalThis.fetch
  * @returns {Object}
  */
 module.exports = (host, client, secret, app) => {
+  const defaultApp = app
   const $ = createRequest(fetch, client, secret)
   return Object.freeze({
     setup: {
       db: () => $.put(`${host}/data/${app}`),
       cache: () => $.put(`${host}/cache/${app}`),
       search: (mappings = {}) => $.put(`${host}/search/${app}`, mappings),
-      queue: (target, secret) => $.put(`${host}/queue/${app}`, { target, secret })
+      queue: (target, { secret, app } = { secret: '', app: defaultApp }) => $.put(`${host}/queue/${app}`, { target, secret })
     },
     cache: {
       query: pattern => $.get(`${host}/cache/${app}/_query?${qs.stringify({ pattern: pattern || '*' })}`),
@@ -47,7 +48,7 @@ module.exports = (host, client, secret, app) => {
       remove: (key) => $.remove(`${host}/search/${app}/${key}`)
     },
     queue: {
-      post: (job) => $.post(`${host}/queue/${app}`, job)
+      post: (job, { app } = { app: defaultApp }) => $.post(`${host}/queue/${app}`, job)
     }
   })
 }

--- a/packages/nodejs-client/index.js
+++ b/packages/nodejs-client/index.js
@@ -22,7 +22,7 @@ module.exports = (host, client, secret, app) => {
       db: () => $.put(`${host}/data/${app}`),
       cache: () => $.put(`${host}/cache/${app}`),
       search: (mappings = {}) => $.put(`${host}/search/${app}`, mappings),
-      queue: (target, { secret, app } = { secret: '', app: defaultApp }) => $.put(`${host}/queue/${app}`, { target, secret })
+      queue: (target, { secret = '', app = defaultApp } = { secret: '', app: defaultApp }) => $.put(`${host}/queue/${app}`, { target, secret })
     },
     cache: {
       query: pattern => $.get(`${host}/cache/${app}/_query?${qs.stringify({ pattern: pattern || '*' })}`),
@@ -48,7 +48,7 @@ module.exports = (host, client, secret, app) => {
       remove: (key) => $.remove(`${host}/search/${app}/${key}`)
     },
     queue: {
-      post: (job, { app } = { app: defaultApp }) => $.post(`${host}/queue/${app}`, job)
+      post: (job, { app = defaultApp } = { app: defaultApp }) => $.post(`${host}/queue/${app}`, job)
     }
   })
 }

--- a/packages/nodejs-client/index_test.js
+++ b/packages/nodejs-client/index_test.js
@@ -8,6 +8,11 @@ globalThis.fetch = fetchMock
     body: { ok: true }
   })
   .post('https://nano.hyper63.com/data/bar/_bulk', { status: '200', body: { ok: true, results: [] } })
+  .put('https://nano.hyper63.com/queue/foo', { status: 201, body: { ok: true } })
+  .put('https://nano.hyper63.com/queue/bar', { status: 201, body: { ok: true } })
+  .post('https://nano.hyper63.com/queue/bar', { status: 200, body: {ok: true }})
+  .post('https://nano.hyper63.com/queue/foo', { status: 200, body: {ok: true }})
+  
   .sandbox()
 
 // globalThis.fetch = fetch
@@ -46,6 +51,43 @@ test('create search index', t => {
 test('post bulk docs', t => {
   t.plan(1)
   services.data.bulk([{ id: '1', name: 'hello' }, { id: '2', name: 'world' }])
+    .fork(
+      () => t.ok(false),
+      () => t.ok(true)
+    )
+})
+
+test('create queue with app name', t => {
+  t.plan(1)
+  services.setup.queue('https://jsonplaceholder.typicode.com/posts', { app: 'bar' })
+    .fork(
+      () => t.ok(false),
+      () => t.ok(true)
+    )
+})
+
+test('create queue with default app', t => {
+  t.plan(1)
+  services.setup.queue('https://jsonplaceholder.typicode.com/posts')
+    .fork(
+      () => t.ok(false),
+      () => t.ok(true)
+    )
+})
+
+test('post job to specific queue', t => {
+  t.plan(1)
+  services.queue.post({ hello: 'world'}, {app: 'bar'})
+    .fork(
+      () => t.ok(false),
+      () => t.ok(true)
+    )
+})
+
+
+test('post job to default queue', t => {
+  t.plan(1)
+  services.queue.post({ hello: 'world'})
     .fork(
       () => t.ok(false),
       () => t.ok(true)


### PR DESCRIPTION
Modified the queue API to accept specific app names for both the creation of the queue and the posting of the job