### PR TITLE
refactor(app-opine): move routing into separate opine Router instance

### DIFF
--- a/packages/app-opine/deps.js
+++ b/packages/app-opine/deps.js
@@ -1,4 +1,4 @@
-export { json, opine } from "https://deno.land/x/opine@1.5.0/mod.ts";
+export { json, opine, Router } from "https://deno.land/x/opine@1.5.0/mod.ts";
 export { opineCors as cors } from "https://deno.land/x/cors@v1.2.1/mod.ts";
 export { lookup as getMimeType } from "https://deno.land/x/media_types@v2.8.4/mod.ts";
 

--- a/packages/app-opine/mod.js
+++ b/packages/app-opine/mod.js
@@ -1,177 +1,30 @@
-import {
-  cors,
-  exists,
-  helmet,
-  json,
-  mountGql,
-  MultipartReader,
-  opine,
-  R,
-} from "./deps.js";
+import { mountGql, opine } from "./deps.js";
 
-import * as cache from "./api/cache.js";
-import * as data from "./api/data.js";
-import * as storage from "./api/storage.js";
-import * as search from "./api/search.js";
-import * as queue from "./api/queue.js";
-
-const { compose } = R;
-
-const TMP_DIR = "/tmp/hyper/uploads";
+import { hyperRouter } from "./router.js";
 
 // opine app
 export default function (services) {
-  // TODO: Maybe refine this and make this a lib?
-  // Upload middleware for handling multipart/formdata ie. files
-  const upload = (fieldName = "file") =>
-    async (req, _res, next) => {
-      let boundary;
-
-      const contentType = req.get("content-type");
-      if (contentType.startsWith("multipart/form-data")) {
-        boundary = contentType.split(";")[1].split("=")[1];
-      }
-
-      // Ensure tmp dir exists. Otherwise MultipartReader throws error when reading form data
-      if (!(await exists(TMP_DIR))) {
-        await Deno.mkdir(TMP_DIR, { recursive: true });
-      }
-
-      const form = await new MultipartReader(req.body, boundary).readForm({
-        maxMemory: 10 << 20,
-        dir: TMP_DIR,
-      });
-
-      // emulate multer
-      req.file = form.file(fieldName);
-
-      next();
-    };
-
-  let app = opine();
-  // enable extensibility to allow
-  // middleware
-  app = services.middleware.length > 0
-    ? compose(...services.middleware)(app)
-    : app;
-
-  const port = Deno.env.get("PORT") ? parseInt(Deno.env.get("PORT")) : 6363;
-
-  // middleware to inject core modules into request object
-  const bindCore = (req, _res, next) => {
-    req.cache = services.cache;
-    req.data = services.data;
-    req.storage = services.storage;
-    req.search = services.search;
-    req.events = services.events;
-    req.hooks = services.hooks;
-    req.queue = services.queue;
-    next();
-  };
-
-  app.use(helmet());
-  app.use(cors({ credentials: true }));
-  // data api
-  app.get("/data", data.index);
-  app.put("/data/:db", bindCore, data.createDb);
-  app.delete("/data/:db", bindCore, data.removeDb);
-  app.get("/data/:db", bindCore, data.listDocuments);
-  app.post("/data/:db", json({ limit: "8mb" }), bindCore, data.createDocument);
-  app.get("/data/:db/:id", bindCore, data.getDocument);
-  app.put(
-    "/data/:db/:id",
-    json({ limit: "8mb" }),
-    bindCore,
-    data.updateDocument,
-  );
-  app.delete("/data/:db/:id", bindCore, data.deleteDocument);
-  app.post("/data/:db/_query", json(), bindCore, data.queryDb);
-  app.post("/data/:db/_index", json(), bindCore, data.indexDb);
-  app.post("/data/:db/_bulk", json(), bindCore, data.bulk);
-
-  // cache api
-  app.get("/cache", bindCore, cache.index);
-  app.put("/cache/:name", bindCore, cache.createStore);
-  app.delete("/cache/:name", bindCore, cache.deleteStore);
-  app.get("/cache/:name/_query", bindCore, cache.queryStore);
-  app.post("/cache/:name/_query", bindCore, cache.queryStore);
-  app.post("/cache/:name", json(), bindCore, cache.createDocument);
-  app.get("/cache/:name/:key", bindCore, cache.getDocument);
-  app.put("/cache/:name/:key", json(), bindCore, cache.updateDocument);
-  app.delete("/cache/:name/:key", bindCore, cache.deleteDocument);
-
-  // storage api
-  app.get("/storage", storage.index);
-  app.put("/storage/:name", bindCore, storage.makeBucket);
-  app.delete("/storage/:name", bindCore, storage.removeBucket);
-  app.post("/storage/:name", upload("file"), bindCore, storage.putObject);
-  app.get("/storage/:name/*", bindCore, storage.getObject);
-  app.delete("/storage/:name/*", bindCore, storage.removeObject);
-
-  // search api
-  app.get("/search", search.index);
-  app.put("/search/:index", json(), bindCore, search.createIndex);
-  app.delete("/search/:index", bindCore, search.deleteIndex);
-  app.post("/search/:index", json(), bindCore, search.indexDoc);
-  app.get("/search/:index/:key", bindCore, search.getDoc);
-  app.put("/search/:index/:key", json(), bindCore, search.updateDoc);
-  app.delete("/search/:index/:key", bindCore, search.removeDoc);
-  app.post("/search/:index/_query", json(), bindCore, search.query);
-  app.post("/search/:index/_bulk", json(), bindCore, search.bulk);
-
-  // queue api
-  app.get("/queue", bindCore, queue.index);
-  app.put("/queue/:name", json(), bindCore, queue.create);
-  app.delete("/queue/:name", bindCore, queue.del);
-  app.post("/queue/:name", json(), bindCore, queue.post);
-  app.get("/queue/:name", bindCore, queue.list);
-  app.post("/queue/:name/_cancel", bindCore, queue.cancel);
-
-  // /graphql
   const playground = Deno.env.get("GQL_PLAYGROUND");
+  const port = Deno.env.get("PORT") ? parseInt(Deno.env.get("PORT")) : 6363;
+  const env = Deno.env.get("DENO_ENV");
+
+  const app = opine();
+
+  // REST
+  app.use(hyperRouter(services));
+
+  // TODO: refactor this to a router like hyperRouter
+  // /graphql
   mountGql(
     { app },
     // disable playground in production by default
     {
       playground: (playground && playground !== "false") ||
-        Deno.env.get("DENO_ENV") !== "production",
+        env !== "production",
     },
   )(services);
 
-  app.get("/error", (_req, _res, next) => {
-    console.log("oooooo");
-    next(new Error("Error occuried"));
-  });
-
-  app.get("/", (_req, res) => {
-    res.send({
-      name: "hyper63",
-      version: "unstable",
-      services: Object
-        .keys(services)
-        .filter((k) => k !== "events")
-        .filter((k) => k !== "middleware")
-        .filter((k) => k !== "hooks")
-        .filter((k) => services[k] !== null),
-    });
-  });
-
-  // TODO: Tyler. Add a favicon?
-  app.get("/favicon.ico", (_req, res) => res.sendStatus(204));
-
-  // All of these args need to be specified, or it won't be invoked on error
-  app.use((err, _req, res, _next) => {
-    if (err) {
-      console.log(JSON.stringify({
-        type: "ERROR",
-        date: new Date().toISOString(),
-        payload: err.message,
-      }));
-      res.setStatus(500).json({ ok: false, msg: err.message });
-    }
-  });
-
-  if (Deno.env.get("DENO_ENV") !== "test") {
+  if (env !== "test") {
     app.listen(port);
     console.log("hyper63 service listening on port ", port);
   }

--- a/packages/app-opine/router.js
+++ b/packages/app-opine/router.js
@@ -1,0 +1,165 @@
+import {
+  cors,
+  exists,
+  helmet,
+  json,
+  MultipartReader,
+  R,
+  Router,
+} from "./deps.js";
+
+import * as cache from "./api/cache.js";
+import * as data from "./api/data.js";
+import * as storage from "./api/storage.js";
+import * as search from "./api/search.js";
+import * as queue from "./api/queue.js";
+
+const { compose } = R;
+
+const TMP_DIR = "/tmp/hyper/uploads";
+
+// Opine Router
+export function hyperRouter(services) {
+  // TODO: Maybe refine this and make this a lib?
+  // Upload middleware for handling multipart/formdata ie. files
+  const upload = (fieldName = "file") =>
+    async (req, _res, next) => {
+      let boundary;
+
+      const contentType = req.get("content-type");
+      if (contentType.startsWith("multipart/form-data")) {
+        boundary = contentType.split(";")[1].split("=")[1];
+      }
+
+      // Ensure tmp dir exists. Otherwise MultipartReader throws error when reading form data
+      if (!(await exists(TMP_DIR))) {
+        await Deno.mkdir(TMP_DIR, { recursive: true });
+      }
+
+      const form = await new MultipartReader(req.body, boundary).readForm({
+        maxMemory: 10 << 20,
+        dir: TMP_DIR,
+      });
+
+      // emulate multer
+      req.file = form.file(fieldName);
+
+      next();
+    };
+
+  /**
+   * This router can be mounted onto other apps,
+   * so we will want access to those req parameters
+   */
+  let app = Router({ mergeParams: true });
+  // enable extensibility to allow
+  // middleware
+  app = services.middleware.length > 0
+    ? compose(...services.middleware)(app)
+    : app;
+
+  // middleware to inject core modules into request object
+  const bindCore = (req, _res, next) => {
+    req.cache = services.cache;
+    req.data = services.data;
+    req.storage = services.storage;
+    req.search = services.search;
+    req.events = services.events;
+    req.hooks = services.hooks;
+    req.queue = services.queue;
+    next();
+  };
+
+  app.use(helmet());
+  app.use(cors({ credentials: true }));
+  // data api
+  app.get("/data", data.index);
+  app.put("/data/:db", bindCore, data.createDb);
+  app.delete("/data/:db", bindCore, data.removeDb);
+  app.get("/data/:db", bindCore, data.listDocuments);
+  app.post("/data/:db", json({ limit: "8mb" }), bindCore, data.createDocument);
+  app.get("/data/:db/:id", bindCore, data.getDocument);
+  app.put(
+    "/data/:db/:id",
+    json({ limit: "8mb" }),
+    bindCore,
+    data.updateDocument,
+  );
+  app.delete("/data/:db/:id", bindCore, data.deleteDocument);
+  app.post("/data/:db/_query", json(), bindCore, data.queryDb);
+  app.post("/data/:db/_index", json(), bindCore, data.indexDb);
+  app.post("/data/:db/_bulk", json(), bindCore, data.bulk);
+
+  // cache api
+  app.get("/cache", bindCore, cache.index);
+  app.put("/cache/:name", bindCore, cache.createStore);
+  app.delete("/cache/:name", bindCore, cache.deleteStore);
+  app.get("/cache/:name/_query", bindCore, cache.queryStore);
+  app.post("/cache/:name/_query", bindCore, cache.queryStore);
+  app.post("/cache/:name", json(), bindCore, cache.createDocument);
+  app.get("/cache/:name/:key", bindCore, cache.getDocument);
+  app.put("/cache/:name/:key", json(), bindCore, cache.updateDocument);
+  app.delete("/cache/:name/:key", bindCore, cache.deleteDocument);
+
+  // storage api
+  app.get("/storage", storage.index);
+  app.put("/storage/:name", bindCore, storage.makeBucket);
+  app.delete("/storage/:name", bindCore, storage.removeBucket);
+  app.post("/storage/:name", upload("file"), bindCore, storage.putObject);
+  app.get("/storage/:name/*", bindCore, storage.getObject);
+  app.delete("/storage/:name/*", bindCore, storage.removeObject);
+
+  // search api
+  app.get("/search", search.index);
+  app.put("/search/:index", json(), bindCore, search.createIndex);
+  app.delete("/search/:index", bindCore, search.deleteIndex);
+  app.post("/search/:index", json(), bindCore, search.indexDoc);
+  app.get("/search/:index/:key", bindCore, search.getDoc);
+  app.put("/search/:index/:key", json(), bindCore, search.updateDoc);
+  app.delete("/search/:index/:key", bindCore, search.removeDoc);
+  app.post("/search/:index/_query", json(), bindCore, search.query);
+  app.post("/search/:index/_bulk", json(), bindCore, search.bulk);
+
+  // queue api
+  app.get("/queue", bindCore, queue.index);
+  app.put("/queue/:name", json(), bindCore, queue.create);
+  app.delete("/queue/:name", bindCore, queue.del);
+  app.post("/queue/:name", json(), bindCore, queue.post);
+  app.get("/queue/:name", bindCore, queue.list);
+  app.post("/queue/:name/_cancel", bindCore, queue.cancel);
+
+  app.get("/error", (_req, _res, next) => {
+    console.log("oooooo");
+    next(new Error("Error occuried"));
+  });
+
+  app.get("/", (_req, res) => {
+    res.send({
+      name: "hyper63",
+      version: "unstable",
+      services: Object
+        .keys(services)
+        .filter((k) => k !== "events")
+        .filter((k) => k !== "middleware")
+        .filter((k) => k !== "hooks")
+        .filter((k) => services[k] !== null),
+    });
+  });
+
+  // TODO: Tyler. Add a favicon?
+  app.get("/favicon.ico", (_req, res) => res.sendStatus(204));
+
+  // All of these args need to be specified, or it won't be invoked on error
+  app.use((err, _req, res, _next) => {
+    if (err) {
+      console.log(JSON.stringify({
+        type: "ERROR",
+        date: new Date().toISOString(),
+        payload: err.message,
+      }));
+      res.setStatus(500).json({ ok: false, msg: err.message });
+    }
+  });
+
+  return app;
+}


### PR DESCRIPTION
This PR basically moves the "guts" of the hyper `opine` app into a `opine` `Router`. Then cleans up some of the code ie. environment variables references at the top of the function, etc.

this will enable pulling in just the router, which is able to merge route params, instead of the entire opine instance, which is not capable of merge route parameters.

`mod.js` still exports a standalone `opine` instance with no breaking changes
`router.js` exports an `opine` `Router` that can be mounted onto other `opine` apps. This will help in our implementation of the SaaS app module that requires an app prefix to be added to all of the routes.