### PR TITLE
fix(core): link is optional for plugins

### DIFF
--- a/packages/core/utils/config-schema.js
+++ b/packages/core/utils/config-schema.js
@@ -14,7 +14,7 @@ const plugin = z.object({
       z.function()
         .args(z.any())
         .returns(z.any()),
-    ),
+    ).optional(),
 });
 
 const Schema = z.object({


### PR DESCRIPTION
`link` is meant to be optional for `plugins`. The use case is that some plugins load data, via `load`, but don't augment the adapter during `link`.

A workaround is to just implement `link` as a passthrough:
```js
{
  link: () => next => next
}
```