### PR TITLE
feat(core): allow ~ and _ in queue and cache store names

### DIFF
--- a/packages/core/lib/cache/store.js
+++ b/packages/core/lib/cache/store.js
@@ -56,7 +56,7 @@ function validName(name) {
   // verify that the name does not contain slashes
   // verify that the name contains URI friendly characters
   // should return a true or false
-  return /^[a-z0-9-]+$/.test(name);
+  return /^[a-z0-9-~_]+$/.test(name);
 }
 
 /**

--- a/packages/core/lib/queue/queue.js
+++ b/packages/core/lib/queue/queue.js
@@ -37,5 +37,5 @@ export const cancel = (input) =>
     .chain(triggerEvent("QUEUE:CANCEL"));
 
 function validName(input) {
-  return /^[a-z0-9-]+$/.test(input.name);
+  return /^[a-z0-9-~_]+$/.test(input.name);
 }


### PR DESCRIPTION
The purpose of these checks are to ensure the names are URI friendly characters.
Both of these characters are allowed in a URI, but not have a reserved purpose
according to rfc3986 section 2.3:

```
2.3.  Unreserved Characters

   Characters that are allowed in a URI but do not have a reserved
   purpose are called unreserved.  These include uppercase and lowercase
   letters, decimal digits, hyphen, period, underscore, and tilde.

      unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
```