### PR TITLE
add cast to descending param and fixed cache name check (#257)

### DIFF
--- a/packages/core/lib/cache/store.js
+++ b/packages/core/lib/cache/store.js
@@ -55,8 +55,9 @@ function validName(name) {
   // verify that the name does not contains spaces
   // verify that the name does not contain slashes
   // verify that the name contains URI friendly characters
+  // cache names should only start with alphanumeric characters
   // should return a true or false
-  return /^[a-z0-9-~_]+$/.test(name);
+  return /^[a-z0-9]+$/.test(name[0]) && /^[a-z0-9-~_]+$/.test(name);
 }
 
 /**

--- a/packages/core/lib/cache/store_test.js
+++ b/packages/core/lib/cache/store_test.js
@@ -32,13 +32,20 @@ test("create cache store", () => {
   );
 });
 
-test("should not create store", () => {
+test("should not create store with space in name", () =>
+  store.create("foo bar").runWith({ svc: mockService, events })
+    .toPromise()
+    .then(() => assertEquals(true, false), () => assertEquals(true, true)));
+
+test("should create store with non alpha in name", () =>
+  store.create("foo_bar").runWith({ svc: mockService, events })
+    .toPromise()
+    .then(() => assertEquals(true, true), () => assertEquals(true, false)));
+
+test("should not create store starting with non alphanumeric", () =>
   store.create("_foo").runWith({ svc: mockService, events })
-    .fork(
-      () => assertEquals(true, true),
-      () => assertEquals(false, true),
-    );
-});
+    .toPromise()
+    .then(() => assertEquals(true, false), () => assertEquals(true, true)));
 
 test("destroy cache store", () => {
   function handleError() {

--- a/packages/core/lib/data/db.js
+++ b/packages/core/lib/data/db.js
@@ -1,4 +1,7 @@
 import { apply, is, of, triggerEvent } from "../utils/mod.js";
+import { R } from "../../deps.js";
+
+const { lensProp, over } = R;
 
 const INVALID_DB_MSG = "database name is not valid";
 const INVALID_RESPONSE = "response is not valid";
@@ -21,8 +24,15 @@ export const query = (db, query) =>
     .chain(apply("queryDocuments"))
     .chain(triggerEvent("DATA:QUERY"));
 
+// convert query param descending to boolean
+const castFieldDescending = over(
+  lensProp("fields"),
+  over(lensProp("descending"), Boolean),
+);
+
 export const index = (db, name, fields) =>
   of({ db, name, fields })
+    .map(castFieldDescending)
     .chain(apply("indexDocuments"))
     .chain(triggerEvent("DATA:INDEX"));
 


### PR DESCRIPTION
added map in core of data/index to convert descending flag to boolean to pass properly to adapter.
also found failing test on cache - checking for special characters on cache name.

Cache names must begin with lowercase letters

https://docs.hyper.io/create-cache-store