### PR TITLE
refactored spec for query documents (#304)

### DIFF
--- a/packages/port-data/mod.js
+++ b/packages/port-data/mod.js
@@ -57,7 +57,10 @@ export function data(adapter) {
         db: z.string(),
         query: z.object({
           selector: z.any(),
-          sort: z.array(z.string()).optional(),
+          fields: z.array(z.string()).optional(),
+          sort: z.array(
+            z.object({}).passthrough().or(z.string()),
+          ).optional(),
           limit: z.number().optional(),
           use_index: z.string().optional(),
         }),

--- a/packages/port-data/mod_test.js
+++ b/packages/port-data/mod_test.js
@@ -14,7 +14,9 @@ Deno.test("data port tests", async () => {
     removeDocument: ({ db, id }) => Promise.resolve({ ok: true, id }),
     listDocuments: ({ db, limit, startkey, endkey, keys, descending }) =>
       Promise.resolve({ ok: true, docs: [] }),
-    queryDocuments: ({ db, query }) => Promise.resolve({ ok: true, docs: [] }),
+    queryDocuments: (
+      { db, query },
+    ) => (console.log(query), Promise.resolve({ ok: true, docs: [] })),
     indexDocuments: ({ db, name, fields }) => Promise.resolve({ ok: true }),
     bulkDocuments: ({ db, docs }) =>
       Promise.resolve({ ok: true, results: [{ ok: true, id: "1" }] }),
@@ -34,6 +36,9 @@ Deno.test("data port tests", async () => {
         selector: {
           id: "bar",
         },
+        fields: ["id"],
+        sort: [{ id: "DESC" }],
+        limit: 10,
       },
     }),
     adapter.indexDocuments({ db: "foo", name: "id", fields: ["id"] }),


### PR DESCRIPTION
In this pull request, I updated the data port schema to support `fields` for the query method, and created a union type for the `sort` prop in the query method. This will enable these features to be active for adapters.

The fields prop works like a select statement where you can specify the specific properties on the document you would like to return.

The sort allows clients to specify how they want the returning documents sorted in either ASC or DESC order by providing an array of objects: [{id: 'DESC'},{ title: 'ASC'}]

By specifying these two query props, the adapters can implement the details of the specification
