### PR TITLE
fixed cache ttl and ms function (#308)

### DIFF
--- a/packages/core/deps.js
+++ b/packages/core/deps.js
@@ -1,7 +1,7 @@
 export * as R from "https://cdn.skypack.dev/ramda@^0.27.1";
 export { default as crocks } from "https://cdn.skypack.dev/crocks@^0.12.4";
 export * as z from "https://cdn.skypack.dev/zod@3.1.0";
-export * as ms from "https://cdn.skypack.dev/ms@2.1.3";
+export { ms } from "https://deno.land/x/ms@v0.1.0/ms.ts";
 
 export { cuid } from "https://deno.land/x/cuid@v1.0.0/index.js";
 export { join } from "https://deno.land/std@0.104.0/path/mod.ts";

--- a/packages/core/lib/cache/doc_test.js
+++ b/packages/core/lib/cache/doc_test.js
@@ -30,7 +30,7 @@ const events = {
 test(
   "create cache doc",
   fork(
-    doc.create("store", "key", { hello: "world" }).runWith({
+    doc.create("store", "key", { hello: "world" }, '20s').runWith({
       svc: mockService,
       events,
     }),


### PR DESCRIPTION
When testing the ttl feature of the cache port, and error was returned unable to use the current `ms` lib, changed to the deno version of the `ms` lib and core tests seem to work.