### PR TITLE
fix index command for connect (#334)

### DIFF
--- a/packages/connect/lib/data.js
+++ b/packages/connect/lib/data.js
@@ -62,11 +62,11 @@ const index = (name, fields) =>
     .map((req) =>
       new Request(req, {
         method: "POST",
-        body: {
-          index: { fields },
+        body: JSON.stringify({
+          fields,
           name,
           type: "json",
-        },
+        }),
       })
     );
 

--- a/packages/connect/mod_test.js
+++ b/packages/connect/mod_test.js
@@ -63,6 +63,17 @@ test("DATA: bulk documents", async () => {
   assertEquals(await req.json(), [{ id: "x-1" }, { id: "x-2" }]);
 });
 
+test("DATA: index database", async () => {
+  const req = await hyper.data.index("idx-name", ["type", "title"]);
+  assertEquals(req.url, "http://localhost:6363/data/test/_index");
+  assertEquals(req.method, "POST");
+  assertEquals(await req.json(), {
+    fields: ["type", "title"],
+    name: "idx-name",
+    type: "json",
+  });
+});
+
 test("CACHE: add key/value", async () => {
   const req = await hyper.cache.add("x-1", {
     type: "test",


### PR DESCRIPTION
refactored data.index method to correctly send a create index command.