### PR TITLE
fix: leverage bulk feature for data list test

### DIFF
--- a/packages/test/data/list-documents.js
+++ b/packages/test/data/list-documents.js
@@ -1,5 +1,5 @@
 import crocks from "crocks";
-import { assoc, concat, lensProp, map, over } from "ramda";
+import { assoc, map } from "ramda";
 import { $fetch, toJSON } from "../lib/utils.js";
 import { assertEquals } from "asserts";
 

--- a/packages/test/data/list-documents.js
+++ b/packages/test/data/list-documents.js
@@ -18,74 +18,73 @@ const docs = [
   { id: "1009", type: "movie", title: "Life Aquatic" },
 ];
 
-const getDocs = (prefix) => map(over(lensProp("id"), concat(prefix)));
+//const getDocs = (prefix) => map(over(lensProp("id"), concat(prefix)));
 export default function (data) {
-  const setup = (prefix) =>
-    $fetch(data.bulk(getDocs(prefix)(docs)))
+  const setup = () =>
+    $fetch(data.bulk(docs))
       .chain(toJSON);
 
   const listDocuments = (flags = {}) => $fetch(data.list(flags)).chain(toJSON);
 
-  const tearDown = (prefix) =>
-    () =>
-      Async.of(getDocs(prefix)(docs))
-        .map(map(assoc("_deleted", true)))
-        .chain((docs) => $fetch(data.bulk(docs)))
-        .chain(toJSON);
+  const tearDown = () =>
+    Async.of(docs)
+      .map(map(assoc("_deleted", true)))
+      .chain((docs) => $fetch(data.bulk(docs)))
+      .chain(toJSON);
 
   test("GET /data/test - get docs with no flags", () =>
-    setup("a")
+    setup()
       .chain(listDocuments)
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 9), r))
-      .chain(tearDown("a"))
+      .chain(tearDown)
       .toPromise());
 
   test("GET /data/test?keys=['1002', '1005', '1008']", () =>
-    setup("b")
-      .chain(() => listDocuments({ keys: ["b1002", "b1005", "b1008"] }))
+    setup()
+      .chain(() => listDocuments({ keys: ["1002", "1005", "1008"] }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 3), r))
-      .chain(tearDown("b"))
+      .chain(tearDown)
       .toPromise());
 
   test("GET /data/test?startkey=1004", () =>
-    setup("c")
-      .chain(() => listDocuments({ startkey: "c1004" }))
+    setup()
+      .chain(() => listDocuments({ startkey: "1004" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 6), r))
-      .chain(tearDown("c"))
+      .chain(tearDown)
       .toPromise());
 
   test("GET /data/test?endkey=1008", () =>
-    setup("d")
-      .chain(() => listDocuments({ endkey: "d1008" }))
+    setup()
+      .chain(() => listDocuments({ endkey: "1008" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 8), r))
-      .chain(tearDown("d"))
+      .chain(tearDown)
       .toPromise());
 
   test("GET /data/test?startkey=1004&endkey=1008", () =>
-    setup("e")
-      .chain(() => listDocuments({ startkey: "e1004", endkey: "e1008" }))
+    setup()
+      .chain(() => listDocuments({ startkey: "1004", endkey: "1008" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 5), r))
-      .chain(tearDown("e"))
+      .chain(tearDown)
       .toPromise());
 
   test("GET /data/test?limt=2", () =>
-    setup("f")
+    setup()
       .chain(() => listDocuments({ limit: 2 }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 2), r))
-      .chain(tearDown("f"))
+      .chain(tearDown)
       .toPromise());
 
   test("GET /data/test?descending=true", () =>
-    setup("g")
+    setup()
       .chain(() => listDocuments({ descending: true }))
       .map((r) => (assertEquals(r.ok, true), r))
-      .map((r) => (assertEquals(r.docs[r.docs.length - 1].id, "g1001"), r))
-      .chain(tearDown("g"))
+      .map((r) => (assertEquals(r.docs[r.docs.length - 1].id, "1001"), r))
+      .chain(tearDown)
       .toPromise());
 }


### PR DESCRIPTION
Changed data list tests to use bulk as it is supposed to work