### PR TITLE
fix: if error response is json return json (#369)

### DIFF
--- a/packages/connect/nodejs/index.js
+++ b/packages/connect/nodejs/index.js
@@ -18,6 +18,9 @@ export default function connect(s) {
         if (r.ok) {
           return r.json();
         } else {
+          if (r.headers.get("content-type").includes("application/json")) {
+            return r.json();
+          }
           return r.text().then((txt) => ({
             ok: r.ok,
             code: r.status,


### PR DESCRIPTION
Fixed bug with hyper connect, when an error is returned, to only return the result if the result is in JSON.