### PR TITLE
fix(utils): fix deepSwap issue with processing array<primitive> nodes…

### DIFF
--- a/packages/utils/deep-swap.js
+++ b/packages/utils/deep-swap.js
@@ -36,6 +36,10 @@ const keySwap = curry((a, b, o) => {
   )(o);
 });
 
+const handleArrayProp = (a, b) =>
+  (k) =>
+    (is(String, k) || is(Number, k) || is(Boolean, k)) ? k : deepSwap(a, b, k);
+
 /**
  * @param {string} - source key
  * @param {string} - dest key
@@ -45,8 +49,9 @@ export const deepSwap = curry(function (a, b, obj) {
   const _reducer = (acc, v) => {
     v[1] = cond([
       [is(Function), identity],
-      [is(Array), map(deepSwap(a, b))],
+      [is(Array), map(handleArrayProp(a, b))],
       [is(Object), deepSwap(a, b)],
+
       [T, identity],
     ])(v[1]);
 

--- a/packages/utils/deep-swap_test.js
+++ b/packages/utils/deep-swap_test.js
@@ -29,3 +29,27 @@ test('deep swap "id" for "_id"', () => {
   const newSelector = deepSwap("id", "_id", selector);
   assertEquals(newSelector, answer);
 });
+
+test("deep swap using $in", () => {
+  const selector = {
+    type: {
+      $in: ["game", "character"],
+    },
+  };
+  const answer = selector;
+
+  const newSelector = deepSwap("id", "_id", selector);
+  assertEquals(newSelector, answer);
+});
+
+test("deep swap using $in", () => {
+  const selector = {
+    type: {
+      $in: [1, 2],
+    },
+  };
+  const answer = selector;
+
+  const newSelector = deepSwap("id", "_id", selector);
+  assertEquals(newSelector, answer);
+});


### PR DESCRIPTION
… (#389)

This PR, fixes a bug in deep swap where the functions was assuming that the node within an array was an object. the fix was to check the type of the node value in the array, if it was a String, Number, Boolean, do nothing, otherwise continue the deep swap.