### PR TITLE
fix(core): don't return _id on create, update, bulk, remove data

### DIFF
--- a/packages/core/lib/data/db.js
+++ b/packages/core/lib/data/db.js
@@ -8,7 +8,7 @@ import {
 } from "../utils/mod.js";
 import { R } from "../../deps.js";
 
-const { lensProp, over, evolve, map } = R;
+const { lensProp, over, evolve, map, compose, omit } = R;
 
 const INVALID_DB_MSG = "database name is not valid";
 const INVALID_RESPONSE = "response is not valid";
@@ -64,7 +64,12 @@ export const bulk = (db, docs) =>
       res.results.forEach(monitorIdUsage("bulkDocuments - result", db));
       return res;
     })
-    .map(evolve({ results: map(mapId) }));
+    .map(evolve({
+      results: compose(
+        map(omit(["_id"])),
+        map(mapId),
+      ),
+    }));
 
 function validDbName() {
   return true;

--- a/packages/core/lib/data/db_test.js
+++ b/packages/core/lib/data/db_test.js
@@ -62,7 +62,6 @@ test(
       .map((res) => {
         res.results.forEach((r) => {
           assert(r.id);
-          assert(r._id);
         });
         return res;
       })

--- a/packages/core/lib/data/doc.js
+++ b/packages/core/lib/data/doc.js
@@ -8,7 +8,7 @@ import {
   triggerEvent,
 } from "../utils/mod.js";
 
-const { compose, assoc } = R;
+const { compose, assoc, omit } = R;
 
 // const INVALID_ID_MSG = 'doc id is not valid'
 const INVALID_RESPONSE = "response is not valid";
@@ -26,6 +26,7 @@ export const create = (db, doc) =>
     .chain(apply("createDocument"))
     .chain(triggerEvent("DATA:CREATE"))
     .map(mapId)
+    .map(omit(["_id"])) // only id is on the api
     .chain(is(validResponse, INVALID_RESPONSE));
 
 export const get = (db, id) =>
@@ -43,13 +44,15 @@ export const update = (db, id, doc) =>
     })
     .chain(apply("updateDocument"))
     .chain(triggerEvent("DATA:UPDATE"))
-    .map(mapId);
+    .map(mapId)
+    .map(omit(["_id"])); // only id is on the api
 
 export const remove = (db, id) =>
   of({ db, id })
     .chain(apply("removeDocument"))
     .chain(triggerEvent("DATA:DELETE"))
-    .map(mapId);
+    .map(mapId)
+    .map(omit(["_id"])); // only id is on the api
 
 function validResponse() {
   return true;

--- a/packages/core/lib/data/doc_test.js
+++ b/packages/core/lib/data/doc_test.js
@@ -40,7 +40,7 @@ test(
   fork(
     doc.create("foo", { hello: "world", _id: "foo", id: "should_be_ignored" })
       .map((res) => {
-        assertEquals(res._id, "foo");
+        assertEquals(res.id, "foo");
         return res;
       })
       .runWith({ svc: mock, events }),
@@ -52,7 +52,7 @@ test(
   fork(
     doc.create("foo", { hello: "world", id: "no _id" })
       .map((res) => {
-        assertEquals(res._id, "no _id");
+        assertEquals(res.id, "no _id");
         return res;
       })
       .runWith({ svc: mock, events }),
@@ -64,7 +64,7 @@ test(
   fork(
     doc.create("foo", { hello: "world" })
       .map((res) => {
-        assert(res._id);
+        assert(res.id);
         return res;
       })
       .runWith({ svc: mock, events }),
@@ -103,7 +103,7 @@ test(
 test(
   "apricot - both id and _id",
   fork(
-    doc.create("foo", { hello: "world" })
+    doc.get("foo", "1")
       .map((res) => {
         assert(res.id);
         assert(res._id);

--- a/packages/core/lib/data/doc_test.js
+++ b/packages/core/lib/data/doc_test.js
@@ -85,6 +85,18 @@ test(
   ),
 );
 
+test(
+  "create document - no document",
+  fork(
+    doc.create("foo")
+      .map((res) => {
+        assertEquals(Object.keys(res.doc).length, 0);
+        return res;
+      })
+      .runWith({ svc: mock, events }),
+  ),
+);
+
 test("get document", fork(doc.get("foo", "1").runWith({ svc: mock, events })));
 test(
   "update document",


### PR DESCRIPTION
Recall we said `_id` only needs to come back on actual documents. So I removed `_id` from `create` `update` `bulk` and `remove` results on the `data` service, leaving only the `id` (which is set to `_id` if not defined)

Also ran `hyper-test` and realized `apricot` broke a test case for `no document`, so added in a fix for that to satisfy the test.

#407 