### PR TITLE
Make hyper-connect compatible with Node 14.x

### DIFF
--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -22,10 +22,13 @@ jobs:
           CI: true
   build-node:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "16.x"
+          node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
       - run: cd packages/connect && yarn && yarn test && yarn build

--- a/packages/connect/src/utils/hyper-request.ts
+++ b/packages/connect/src/utils/hyper-request.ts
@@ -4,9 +4,9 @@ import { HyperRequest, Method } from "../types";
 import { BodyInit, Headers } from "node-fetch";
 
 // deno-lint-ignore no-explicit-any
-const generateToken = async (sub: string, secret: any) => {
+export const generateToken = async (sub: string, secret: any) => {
   const crypto = await import("crypto");
-  const key = crypto.createSecretKey(secret);
+  const key = crypto.createSecretKey(Buffer.from(secret, "utf-8"));
   const token = await new SignJWT({ sub })
     .setProtectedHeader({ alg: "HS256" })
     .setExpirationTime("10m")

--- a/packages/connect/tests/hyper-request.ts
+++ b/packages/connect/tests/hyper-request.ts
@@ -1,0 +1,14 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { generateToken } from "../src/utils/hyper-request";
+
+test("generateToken", async () => {
+  try {
+    await generateToken("SUB", "SECRET");
+    assert.ok(true);
+  } catch (error) {
+    assert.ok(false, (error as Error).message);
+  }
+});
+
+test.run();


### PR DESCRIPTION
### Context

When attempting to first use the connect client immediately after initialization (**with Node v14.x**), we receive the following error:

`The "key" argument must be an instance of Buffer, TypedArray, or DataView. Received type string ('...')`

![Screen Shot 2021-12-16 at 3 24 59 PM](https://user-images.githubusercontent.com/65454/146444230-61c79b01-2e47-45e6-a320-c7a2b74cfe1b.png)

Given that the most recent Node runtimes for AWS lambda is still `v14.x` and is likely to be so for a while longer (_reference needed_), it would be nice to get it to run in `v14.x`.

### Changes Made

- Added Node v14 to the testing matrix
- Added a failing test to demonstrate issue when using newly initialized connect client under Node v14
- ~Added `crypto` to as an explicit dependency since this was imported in code~ (Thanks for the info @TillaTheHun0) 
- Converted secret into buffer before invoking `crypto.createSecretKey`. For some reason this worked with a string under Node 16, but not Node 14 🤷‍♂️ 

### Testing

I'm creating this under a fork, so **checks** aren't running. Not sure the best way to go about running checks. If nothing else, maybe this can just serve as a possible idea for a fix.

But what I did locally, was to:

1. Create the failing test and verify that it did indeed fail under Node 14
2. Made my changes
3. Switched to Node 16, reinstalled dependencies and verified that the test now passed