### PR TITLE
fix(test): hyper test take into account extra _id key

### DIFF
--- a/packages/test/data/query-documents.js
+++ b/packages/test/data/query-documents.js
@@ -73,7 +73,7 @@ export default function (data) {
     tearDown().chain(setup)
       .chain(query({ type: "album" }, { fields: ["id", "band"] }))
       .map((r) => (assertEquals(r.ok, true), r))
-      .map((r) => (assertEquals(keys(r.docs[0]).length, 2), r))
+      .map((r) => (assertEquals(keys(r.docs[0]).length, 2 + 1), r)) // +1 because _id and id are being added to result by core
       .chain(tearDown)
       .toPromise());
 }


### PR DESCRIPTION
`core` is adding an extra key `id` or `_id` to each document, so we take this into account for `hyper-test` for `apricot` release

This will need to be removed as part of the `blueberry` phase