### PR TITLE
refactor(core): do not map to id where it is enforced by the port

### DIFF
--- a/packages/core/lib/data/db.js
+++ b/packages/core/lib/data/db.js
@@ -8,7 +8,7 @@ import {
 } from "../utils/mod.js";
 import { R } from "../../deps.js";
 
-const { lensProp, over, evolve, map, compose, omit } = R;
+const { lensProp, over, evolve, map } = R;
 
 const INVALID_DB_MSG = "database name is not valid";
 const INVALID_RESPONSE = "response is not valid";
@@ -59,17 +59,7 @@ export const bulk = (db, docs) =>
       return args;
     })
     .chain(apply("bulkDocuments"))
-    .chain(triggerEvent("DATA:BULK"))
-    .map((res) => {
-      res.results.forEach(monitorIdUsage("bulkDocuments - result", db));
-      return res;
-    })
-    .map(evolve({
-      results: compose(
-        map(omit(["_id"])),
-        map(mapId),
-      ),
-    }));
+    .chain(triggerEvent("DATA:BULK"));
 
 function validDbName() {
   return true;

--- a/packages/core/lib/data/db_test.js
+++ b/packages/core/lib/data/db_test.js
@@ -14,7 +14,7 @@ const mockDb = {
     if (docs.length === 2) {
       return Promise.resolve({
         ok: true,
-        results: [{ ok: true, _id: "1" }, { ok: true, _id: "2" }],
+        results: [{ ok: true, id: "1" }, { ok: true, id: "2" }],
       });
     } else {
       return Promise.reject({ ok: false });

--- a/packages/core/lib/data/doc.js
+++ b/packages/core/lib/data/doc.js
@@ -30,8 +30,6 @@ export const create = (db, doc) =>
     .map((doc) => ({ db, id: doc._id || cuid(), doc }))
     .chain(apply("createDocument"))
     .chain(triggerEvent("DATA:CREATE"))
-    .map(mapId)
-    .map(omit(["_id"])) // only id is on the api
     .chain(is(validResponse, INVALID_RESPONSE));
 
 export const get = (db, id) =>
@@ -49,15 +47,15 @@ export const update = (db, id, doc) =>
     })
     .chain(apply("updateDocument"))
     .chain(triggerEvent("DATA:UPDATE"))
+    // TODO: id not enforced on port. Should it be?
+    // For now, just mapping to id to match docs
     .map(mapId)
-    .map(omit(["_id"])); // only id is on the api
+    .map(omit(["_id"]));
 
 export const remove = (db, id) =>
   of({ db, id })
     .chain(apply("removeDocument"))
-    .chain(triggerEvent("DATA:DELETE"))
-    .map(mapId)
-    .map(omit(["_id"])); // only id is on the api
+    .chain(triggerEvent("DATA:DELETE"));
 
 function validResponse() {
   return true;

--- a/packages/core/lib/data/doc_test.js
+++ b/packages/core/lib/data/doc_test.js
@@ -5,13 +5,13 @@ const test = Deno.test;
 
 const mock = {
   createDocument({ db, id, doc }) {
-    return Promise.resolve({ ok: true, _id: id, doc });
+    return Promise.resolve({ ok: true, id: id, doc });
   },
   retrieveDocument({ db, id }) {
     return Promise.resolve({ _id: id });
   },
   updateDocument({ db, id, doc }) {
-    return Promise.resolve({ ok: true, _id: id });
+    return Promise.resolve({ ok: true, id: id });
   },
   removeDocument({ db, id }) {
     return Promise.resolve({ ok: true });


### PR DESCRIPTION
The port enforces `id` to come back on most apis, so mapping in core is not needed, as it's a the job of adapters to ensure id is returned in that case. Otherwise the port will produce an error.