### PR TITLE
refactor(test)!: id -> _id in data test suite #421

### DIFF
--- a/packages/test/data/bulk-documents.js
+++ b/packages/test/data/bulk-documents.js
@@ -6,12 +6,12 @@ import { assertEquals } from "asserts";
 const test = Deno.test;
 
 const teams = [
-  { id: "3001", type: "team", name: "Falcons", region: "Atlanta" },
-  { id: "3002", type: "team", name: "Panthers", region: "Carolina" },
-  { id: "3003", type: "team", name: "Cardinals", region: "Arizona" },
-  { id: "3004", type: "team", name: "Bears", region: "Chicago" },
-  { id: "3005", type: "team", name: "Eagles", region: "Philidelphia" },
-  { id: "3006", type: "team", name: "Giants", region: "New York" },
+  { _id: "3001", type: "team", name: "Falcons", region: "Atlanta" },
+  { _id: "3002", type: "team", name: "Panthers", region: "Carolina" },
+  { _id: "3003", type: "team", name: "Cardinals", region: "Arizona" },
+  { _id: "3004", type: "team", name: "Bears", region: "Chicago" },
+  { _id: "3005", type: "team", name: "Eagles", region: "Philidelphia" },
+  { _id: "3006", type: "team", name: "Giants", region: "New York" },
 ];
 
 export default function (data) {

--- a/packages/test/data/create-document.js
+++ b/packages/test/data/create-document.js
@@ -15,14 +15,14 @@ export default function (data) {
       .toPromise());
 
   test("POST /data/:store with id successfully", () =>
-    createDocument({ id: "10", type: "test" })
+    createDocument({ _id: "10", type: "test" })
       .map((r) => (assert(r.id === "10"), r.id))
       .chain(cleanUp)
       .toPromise());
 
   test("POST /data/:store document conflict", () =>
-    createDocument({ id: "2", type: "test" })
-      .chain(() => createDocument({ id: "2", type: "test" }))
+    createDocument({ _id: "2", type: "test" })
+      .chain(() => createDocument({ _id: "2", type: "test" }))
       .map((r) => (assertEquals(r.ok, false), r))
       .map((r) => (assertEquals(r.status, 409), r.id))
       .chain(() => cleanUp("2"))

--- a/packages/test/data/list-documents.js
+++ b/packages/test/data/list-documents.js
@@ -1,21 +1,21 @@
 import crocks from "crocks";
 import { assoc, map } from "ramda";
 import { $fetch } from "../lib/utils.js";
-import { assertEquals } from "asserts";
+import { assert, assertEquals } from "asserts";
 
 const { Async } = crocks;
 const test = Deno.test;
 
 const docs = [
-  { id: "1001", type: "movie", title: "Ghostbusters" },
-  { id: "1002", type: "movie", title: "Ghostbusters 2" },
-  { id: "1003", type: "movie", title: "Groundhog Day" },
-  { id: "1004", type: "movie", title: "Scrooged" },
-  { id: "1005", type: "movie", title: "Caddyshack" },
-  { id: "1006", type: "movie", title: "Meatballs" },
-  { id: "1007", type: "movie", title: "Stripes" },
-  { id: "1008", type: "movie", title: "What about Bob?" },
-  { id: "1009", type: "movie", title: "Life Aquatic" },
+  { _id: "1001", type: "movie", title: "Ghostbusters" },
+  { _id: "1002", type: "movie", title: "Ghostbusters 2" },
+  { _id: "1003", type: "movie", title: "Groundhog Day" },
+  { _id: "1004", type: "movie", title: "Scrooged" },
+  { _id: "1005", type: "movie", title: "Caddyshack" },
+  { _id: "1006", type: "movie", title: "Meatballs" },
+  { _id: "1007", type: "movie", title: "Stripes" },
+  { _id: "1008", type: "movie", title: "What about Bob?" },
+  { _id: "1009", type: "movie", title: "Life Aquatic" },
 ];
 
 //const getDocs = (prefix) => map(over(lensProp("id"), concat(prefix)));
@@ -35,6 +35,7 @@ export default function (data) {
       .chain(listDocuments)
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 9), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -44,6 +45,7 @@ export default function (data) {
       .chain(() => listDocuments({ keys: ["1002", "1005", "1008"] }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 3), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -53,6 +55,7 @@ export default function (data) {
       .chain(() => listDocuments({ startkey: "1004" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 6), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -62,6 +65,7 @@ export default function (data) {
       .chain(() => listDocuments({ endkey: "1008" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 8), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -71,6 +75,7 @@ export default function (data) {
       .chain(() => listDocuments({ startkey: "1004", endkey: "1008" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 5), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -80,6 +85,7 @@ export default function (data) {
       .chain(() => listDocuments({ limit: 2 }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 2), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -88,7 +94,8 @@ export default function (data) {
       .chain(setup)
       .chain(() => listDocuments({ descending: true }))
       .map((r) => (assertEquals(r.ok, true), r))
-      .map((r) => (assertEquals(r.docs[r.docs.length - 1].id, "1001"), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
+      .map((r) => (assertEquals(r.docs[r.docs.length - 1]._id, "1001"), r))
       .chain(tearDown)
       .toPromise());
 }

--- a/packages/test/data/query-documents.js
+++ b/packages/test/data/query-documents.js
@@ -1,27 +1,27 @@
 import crocks from "crocks";
 import { assoc, keys, map } from "ramda";
 import { $fetch } from "../lib/utils.js";
-import { assertEquals } from "asserts";
+import { assert, assertEquals } from "asserts";
 
 const { Async } = crocks;
 const test = Deno.test;
 
 const albums = [
   {
-    id: "2001",
+    _id: "2001",
     type: "album",
     title: "Nothing Shocking",
     band: "Janes Addiction",
   },
   {
-    id: "2002",
+    _id: "2002",
     type: "album",
     title: "Appetite for Destruction",
     band: "Guns and Roses",
   },
-  { id: "2003", type: "album", title: "Back in Black", band: "ACDC" },
-  { id: "2004", type: "album", title: "The Doors", band: "Doors" },
-  { id: "2005", type: "album", title: "Nevermind", band: "Nirvana" },
+  { _id: "2003", type: "album", title: "Back in Black", band: "ACDC" },
+  { _id: "2004", type: "album", title: "The Doors", band: "Doors" },
+  { _id: "2005", type: "album", title: "Nevermind", band: "Nirvana" },
 ];
 
 export default function (data) {
@@ -42,13 +42,15 @@ export default function (data) {
       .chain(query({ type: "album" }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 5), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
   test("POST /data/:store/_query - query documents with no selector", () =>
     tearDown().chain(setup)
       .chain(query())
-      .map((r) => (assertEquals(r.docs.length, 5)))
+      .map((r) => (assertEquals(r.docs.length, 5), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -57,6 +59,7 @@ export default function (data) {
       .chain(query({ type: "album" }, { limit: 2 }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (assertEquals(r.docs.length, 2), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
@@ -65,14 +68,17 @@ export default function (data) {
       .chain(createIndex)
       .chain(query({ type: "album" }, { sort: [{ title: "DESC" }] }))
       .map((r) => (assertEquals(r.ok, true), r))
-      .map((r) => (assertEquals(r.docs[0].id, "2004"), r))
+      .map((r) => (assertEquals(r.docs[0]._id, "2004"), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
       .chain(tearDown)
       .toPromise());
 
   test("POST /data/:store/_query - query selector - select fields", () =>
     tearDown().chain(setup)
-      .chain(query({ type: "album" }, { fields: ["id", "band"] }))
+      .chain(query({ type: "album" }, { fields: ["_id", "band"] }))
       .map((r) => (assertEquals(r.ok, true), r))
+      .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
+      // TODO: remove +1 in corncob
       .map((r) => (assertEquals(keys(r.docs[0]).length, 2 + 1), r)) // +1 because _id and id are being added to result by core
       .chain(tearDown)
       .toPromise());

--- a/packages/test/data/remove-document.js
+++ b/packages/test/data/remove-document.js
@@ -23,11 +23,11 @@ export default function (data) {
   */
 
   test("DELETE /data/:store/:id - delete document successfully", () =>
-    createDocument({ id: "DELETE", type: "test" })
+    createDocument({ _id: "DELETE", type: "test" })
       .chain(() => retrieveDocument("DELETE"))
-      .map((r) => (assertEquals(r.id, "DELETE"), r))
+      .map((r) => (assertEquals(r._id, "DELETE"), r))
       .map((r) => (assertEquals(r.type, "test"), r))
-      .map(prop("id"))
+      .map(prop("_id"))
       .chain(removeDocument)
       .map((r) => (assertEquals(r.ok, true), r))
       .toPromise());

--- a/packages/test/data/retrieve-document.js
+++ b/packages/test/data/retrieve-document.js
@@ -6,7 +6,7 @@ const test = Deno.test;
 export default function (data) {
   const setup = () =>
     $fetch(
-      () => data.add({ id: "42", type: "test" }),
+      () => data.add({ _id: "42", type: "test" }),
     );
 
   const tearDown = () => $fetch(() => data.remove("42"));
@@ -21,7 +21,7 @@ export default function (data) {
   test("GET /data/:store/:id - success", () =>
     setup()
       .chain(retrieve("42"))
-      .map((result) => (assertEquals(result.id, "42"), result))
+      .map((result) => (assertEquals(result._id, "42"), result))
       .chain(tearDown)
       .toPromise());
 }

--- a/packages/test/data/update-document.js
+++ b/packages/test/data/update-document.js
@@ -16,10 +16,10 @@ export default function (data) {
   */
 
   test("PUT /data/:store/:id - update document should be successful", () =>
-    create({ id: "63", type: "test" })
+    create({ _id: "63", type: "test" })
       .chain(
         () =>
-          update({ id: "63", doc: { id: "63", type: "test", name: "foo" } }),
+          update({ id: "63", doc: { _id: "63", type: "test", name: "foo" } }),
       )
       .map((result) => (assertEquals(result.ok, true), "63"))
       .chain(remove) // cleanup


### PR DESCRIPTION
This PR updates `hyper-test` to create documents with `_id` and to test for the presence of `_id` on documents as opposed to `id`.

To align with the rest of the blueberry releases. I propose we also major bump `hyper-test` to `v2.0.0`

This is meant to be the gold standard for testing adapters for correctness and completion.

Closes #421 