### PR TITLE
feat!(core): remove inbound id mapping #412

### DIFF
--- a/packages/core/lib/data/doc.js
+++ b/packages/core/lib/data/doc.js
@@ -8,25 +8,15 @@ import {
   triggerEvent,
 } from "../utils/mod.js";
 
-const { compose, assoc, ifElse, isNil, isEmpty, omit, always } = R;
+const { omit, defaultTo } = R;
 
 // const INVALID_ID_MSG = 'doc id is not valid'
 const INVALID_RESPONSE = "response is not valid";
 
-// If no document, just passthrough
-const setIds = ifElse(
-  (doc) => isNil(doc) || isEmpty(doc),
-  always({}),
-  compose(
-    (doc) => assoc("id", doc.id || doc._id)(doc), // _id is guaranteed to be set
-    (doc) => assoc("_id", doc._id || doc.id || cuid())(doc),
-  ),
-);
-
 export const create = (db, doc) =>
   of(doc)
     .map(monitorIdUsage("createDocument - args", db))
-    .map(setIds)
+    .map(defaultTo({}))
     .map((doc) => ({ db, id: doc._id || cuid(), doc }))
     .chain(apply("createDocument"))
     .chain(triggerEvent("DATA:CREATE"))

--- a/packages/core/lib/data/doc_test.js
+++ b/packages/core/lib/data/doc_test.js
@@ -5,7 +5,7 @@ const test = Deno.test;
 
 const mock = {
   createDocument({ db, id, doc }) {
-    return Promise.resolve({ ok: true, id: id, doc });
+    return Promise.resolve({ ok: true, id, doc });
   },
   retrieveDocument({ db, id }) {
     return Promise.resolve({ _id: id });
@@ -48,11 +48,12 @@ test(
 );
 
 test(
-  "create document - use id",
+  "create document - do NOT use id and generate id",
   fork(
-    doc.create("foo", { hello: "world", id: "no _id" })
+    doc.create("foo", { hello: "world", id: "should_be_ignored" })
       .map((res) => {
-        assertEquals(res.id, "no _id");
+        assert(res.id);
+        assert(res.id !== "should_be_ignored");
         return res;
       })
       .runWith({ svc: mock, events }),
@@ -65,20 +66,6 @@ test(
     doc.create("foo", { hello: "world" })
       .map((res) => {
         assert(res.id);
-        return res;
-      })
-      .runWith({ svc: mock, events }),
-  ),
-);
-
-test(
-  "create document - set ids on doc",
-  fork(
-    doc.create("foo", { hello: "world", _id: "foo" })
-      .map((res) => {
-        assert(res.doc._id);
-        assert(res.doc.id);
-        assertEquals(res.doc.id, res.doc._id);
         return res;
       })
       .runWith({ svc: mock, events }),
@@ -113,7 +100,7 @@ test(
 );
 
 test(
-  "apricot - both id and _id",
+  "corncob - keep outbound id and _id",
   fork(
     doc.get("foo", "1")
       .map((res) => {


### PR DESCRIPTION
Closes #412 
Closes #413 

This PR makes it so `core` does not map `id` on the doc to `_id` and vice versa. **The outbound mapping is still kept**

BREAKING CHANGE

I propose we bump `core` to `v2.0.0` on this change.