### PR TITLE
fix(app-opine): consistently construct error sent back to client

### DIFF
--- a/packages/app-opine/utils.js
+++ b/packages/app-opine/utils.js
@@ -1,13 +1,12 @@
 export const fork = (res, code, m) =>
   m.fork(
     (error) => {
-      if (error.status) {
-        return res.setStatus(error.status).send({
-          ok: false,
-          msg: error.message,
-        });
-      }
-      res.setStatus(500).send(error);
+      const status = error.status || 500;
+      res.setStatus(status).send({
+        ...error,
+        ok: false,
+        msg: error.msg || error.message,
+      });
     },
     (result) => res.setStatus(code).send(result),
   );


### PR DESCRIPTION
before, `message` was mapped to `msg` only if `status` was set. Otherwise, error was sent back, which could be anything.

This PR makes it such that every error response from `app-opine` will have `ok: false` and `msg`, and then whatever else is included on the `error` from `core`