### PR TITLE
fix(app-opine): conditionally sanitize error responses

### DIFF
--- a/packages/app-opine/utils.js
+++ b/packages/app-opine/utils.js
@@ -1,9 +1,16 @@
+const isProduction = () => {
+  const env = Deno.env.get("DENO_ENV");
+  // Default to production behavior if no DENO_ENV is set
+  return !env || env === "production";
+};
+
 export const fork = (res, code, m) =>
   m.fork(
     (error) => {
       const status = error.status || 500;
       res.setStatus(status).send({
-        ...error,
+        // sanitize response, if production.
+        ...(isProduction() ? {} : error),
         ok: false,
         msg: error.msg || error.message,
       });


### PR DESCRIPTION
With the change in `1.2.9` I am seeing some large error responses from hyper. I think it's good for the adapter to send back additional context on the error response, but we should sanitize the response to the client, in some cases.

This PR conditionally sanitize the error response from `app-opine`. If `DENO_ENV` is unset or set to `production`, only include `{ ok, msg }` on the response. Otherwise, send the entire error in the response. hyper core still logs the entire error received from the adapter.