### PR TITLE
feat(port-storage): overload putObject to support file upload and signed url flow #444

### DIFF
--- a/packages/port-storage/dev_deps.js
+++ b/packages/port-storage/dev_deps.js
@@ -1,2 +1,3 @@
 // dev dependencies here
-export { assert } from "https://deno.land/std@0.107.0/testing/asserts.ts";
+export { assert } from "https://deno.land/std@0.123.0/testing/asserts.ts";
+export { Buffer } from "https://deno.land/std@0.123.0/io/buffer.ts";

--- a/packages/port-storage/dev_deps_lock.json
+++ b/packages/port-storage/dev_deps_lock.json
@@ -1,5 +1,11 @@
 {
-  "https://deno.land/std@0.107.0/fmt/colors.ts": "8368ddf2d48dfe413ffd04cdbb7ae6a1009cf0dccc9c7ff1d76259d9c61a0621",
-  "https://deno.land/std@0.107.0/testing/_diff.ts": "ccd6c3af6e44c74bf1591acb1361995f5f50df64323a6e7fb3f16c8ea792c940",
-  "https://deno.land/std@0.107.0/testing/asserts.ts": "05ab5d53d1e2b8402987c50c622d6d8e6f89d63c0798ab26923ea5fcbe10f9ed"
+  "https://deno.land/std@0.123.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
+  "https://deno.land/std@0.123.0/bytes/bytes_list.ts": "3bff6a09c72b2e0b1e92e29bd3b135053894196cca07a2bba842901073efe5cb",
+  "https://deno.land/std@0.123.0/bytes/equals.ts": "69f55fdbd45c71f920c1a621e6c0865dc780cd8ae34e0f5e55a9497b70c31c1b",
+  "https://deno.land/std@0.123.0/bytes/mod.ts": "fedb80b8da2e7ad8dd251148e65f92a04c73d6c5a430b7d197dc39588c8dda6f",
+  "https://deno.land/std@0.123.0/fmt/colors.ts": "8368ddf2d48dfe413ffd04cdbb7ae6a1009cf0dccc9c7ff1d76259d9c61a0621",
+  "https://deno.land/std@0.123.0/io/buffer.ts": "8f10342821b81990acf859cdccb4e4031c7c9187a0ffc3ed6b356ee29ecc6681",
+  "https://deno.land/std@0.123.0/io/types.d.ts": "89a27569399d380246ca7cdd9e14d5e68459f11fb6110790cc5ecbd4ee7f3215",
+  "https://deno.land/std@0.123.0/testing/_diff.ts": "e6a10d2aca8d6c27a9c5b8a2dbbf64353874730af539707b5b39d4128140642d",
+  "https://deno.land/std@0.123.0/testing/asserts.ts": "437505f8490a4d261836d822d3418bdd2b152007bdc9b01bdc339bf4b88983a2"
 }

--- a/packages/port-storage/mod.js
+++ b/packages/port-storage/mod.js
@@ -1,5 +1,27 @@
 import { z } from "./deps.js";
 
+const putObjectUploadSchemaArgs = z.object({
+  bucket: z.string(),
+  object: z.string(),
+  stream: z.object({}).passthrough(),
+  // omitting is falsey, so make it optional, but MUST be false if defined
+  doReturnUrl: z.literal(false).optional(),
+});
+const putObjectUploadSchema = z.function()
+  .args(putObjectUploadSchemaArgs)
+  .returns(z.promise(z.object({ ok: z.boolean(), url: z.void() })));
+
+const putObjectSignedUrlSchemaArgs = z.object({
+  bucket: z.string(),
+  object: z.string(),
+  // MUST NOT be provided alongside doReturnUrl
+  stream: z.void(),
+  doReturnUrl: z.literal(true),
+});
+const putObjectSignedUrlSchema = z.function()
+  .args(putObjectSignedUrlSchemaArgs)
+  .returns(z.promise(z.object({ ok: z.boolean(), url: z.string().url() })));
+
 /**
  * @param {function} adapter - implementation detail for this port
  * @param {object} env - environment settings for the adapter
@@ -19,18 +41,18 @@ export function storage(adapter) {
         msg: z.string().optional(),
       }))),
     listBuckets: z.function()
-      .args(z.void())
+      .args()
       .returns(z.promise(z.object({
         ok: z.boolean(),
         buckets: z.array(z.string()),
       }))),
     putObject: z.function()
-      .args(z.object({
-        bucket: z.string(),
-        object: z.string(),
-        stream: z.any(),
-      }))
-      .returns(z.promise(z.object({ ok: z.boolean() }))),
+      .args(z.union([
+        putObjectUploadSchemaArgs,
+        putObjectSignedUrlSchemaArgs,
+      ]))
+      // validation of return is handled by subschemas
+      .returns(z.promise(z.any())),
     removeObject: z.function()
       .args(z.object({
         bucket: z.string(),
@@ -50,13 +72,31 @@ export function storage(adapter) {
       }))
       .returns(z.promise(z.any())),
   });
+
   const instance = Port.parse(adapter);
+
   instance.makeBucket = Port.shape.makeBucket.validate(instance.makeBucket);
   instance.removeBucket = Port.shape.removeBucket.validate(
     instance.removeBucket,
   );
   instance.listBuckets = Port.shape.listBuckets.validate(instance.listBuckets);
-  instance.putObject = Port.shape.putObject.validate(instance.putObject);
+
+  const original = instance.putObject;
+  instance.putObject = Port.shape.putObject.implement((params) => {
+    /**
+     * params are already validated against union type
+     * so now determine which function type to use for full
+     * end-to-end validation
+     */
+    if (!params.doReturnUrl) {
+      // upload request
+      return putObjectUploadSchema.validate(original)(params);
+    }
+
+    // signed url request
+    return putObjectSignedUrlSchema.validate(original)(params);
+  });
+
   instance.removeObject = Port.shape.removeObject.validate(
     instance.removeObject,
   );

--- a/packages/port-storage/mod.js
+++ b/packages/port-storage/mod.js
@@ -5,7 +5,7 @@ const putObjectUploadSchemaArgs = z.object({
   object: z.string(),
   stream: z.object({}).passthrough(),
   // omitting is falsey, so make it optional, but MUST be false if defined
-  doReturnUrl: z.literal(false).optional(),
+  useSignedUrl: z.literal(false).optional(),
 });
 const putObjectUploadSchema = z.function()
   .args(putObjectUploadSchemaArgs)
@@ -14,9 +14,9 @@ const putObjectUploadSchema = z.function()
 const putObjectSignedUrlSchemaArgs = z.object({
   bucket: z.string(),
   object: z.string(),
-  // MUST NOT be provided alongside doReturnUrl
+  // MUST NOT be provided alongside useSignedUrl
   stream: z.void(),
-  doReturnUrl: z.literal(true),
+  useSignedUrl: z.literal(true),
 });
 const putObjectSignedUrlSchema = z.function()
   .args(putObjectSignedUrlSchemaArgs)
@@ -88,7 +88,7 @@ export function storage(adapter) {
      * so now determine which function type to use for full
      * end-to-end validation
      */
-    if (!params.doReturnUrl) {
+    if (!params.useSignedUrl) {
       // upload request
       return putObjectUploadSchema.validate(original)(params);
     }

--- a/packages/port-storage/mod_test.js
+++ b/packages/port-storage/mod_test.js
@@ -60,7 +60,7 @@ Deno.test("validate putObject - always validate 'bucket' and 'object' params", a
   err = await adapter.putObject({
     no_bucket: "foo",
     object: "bar.jpg",
-    doReturnUrl: true,
+    useSignedUrl: true,
   }).catch(() => ({ ok: false }));
 
   assert(!err.ok);
@@ -89,12 +89,12 @@ Deno.test("validate putObject upload - no stream", async () => {
 });
 
 Deno.test("validate putObject upload - conflicting params", async () => {
-  // conflicting params by passing both doReturnUrl: true and stream
+  // conflicting params by passing both useSignedUrl: true and stream
   const err = await adapter.putObject({
     bucket: "foo",
     object: "bar.jpg",
     stream: new Buffer(new Uint8Array(4).buffer),
-    doReturnUrl: true,
+    useSignedUrl: true,
   }).catch(() => ({ ok: false }));
 
   assert(!err.ok);
@@ -104,7 +104,7 @@ Deno.test("validate putObject upload - invalid return", async () => {
   // invalid return
   adapter = storagePort({
     ...wrap,
-    putObject: ({ bucket, object, doReturnUrl }) =>
+    putObject: ({ bucket, object, useSignedUrl }) =>
       Promise.resolve({ ok: true, url: "https://foo.ar" }),
   });
 
@@ -123,7 +123,7 @@ Deno.test("validate putObject upload - invalid return", async () => {
 Deno.test("validate putObject signedUrl", async () => {
   adapter = storagePort({
     ...wrap,
-    putObject: ({ bucket, object, doReturnUrl }) =>
+    putObject: ({ bucket, object, useSignedUrl }) =>
       Promise.resolve({ ok: true, url: "https://foo.ar" }),
   });
 
@@ -131,7 +131,7 @@ Deno.test("validate putObject signedUrl", async () => {
   const res = await adapter.putObject({
     bucket: "foo",
     object: "bar.jpg",
-    doReturnUrl: true,
+    useSignedUrl: true,
   });
 
   assert(res.ok);
@@ -141,18 +141,18 @@ Deno.test("validate putObject signedUrl", async () => {
   adapter = storagePort(wrap);
 });
 
-Deno.test("validate putObject signedUrl - invalid doReturnUrl false", async () => {
+Deno.test("validate putObject signedUrl - invalid useSignedUrl false", async () => {
   adapter = storagePort({
     ...wrap,
-    putObject: ({ bucket, object, doReturnUrl }) =>
+    putObject: ({ bucket, object, useSignedUrl }) =>
       Promise.resolve({ ok: true, url: "https://foo.ar" }),
   });
 
-  // doReturnUrl false
+  // useSignedUrl false
   const err = await adapter.putObject({
     bucket: "foo",
     object: "bar.jpg",
-    doReturnUrl: false,
+    useSignedUrl: false,
   }).catch(() => ({ ok: false }));
 
   assert(!err.ok);
@@ -164,16 +164,16 @@ Deno.test("validate putObject signedUrl - invalid doReturnUrl false", async () =
 Deno.test("validate putObject signedUrl - conflicting params", async () => {
   adapter = storagePort({
     ...wrap,
-    putObject: ({ bucket, object, doReturnUrl }) =>
+    putObject: ({ bucket, object, useSignedUrl }) =>
       Promise.resolve({ ok: true, url: "https://foo.ar" }),
   });
 
-  // conflicting params by passing both doReturnUrl: true and stream
+  // conflicting params by passing both useSignedUrl: true and stream
   const err = await adapter.putObject({
     bucket: "foo",
     object: "bar.jpg",
     stream: new Buffer(new Uint8Array(4).buffer),
-    doReturnUrl: true,
+    useSignedUrl: true,
   }).catch(() => ({ ok: false }));
 
   assert(!err.ok);
@@ -185,14 +185,14 @@ Deno.test("validate putObject signedUrl - conflicting params", async () => {
 Deno.test("validate putObject signedUrl - invalid url in return", async () => {
   adapter = storagePort({
     ...wrap,
-    putObject: ({ bucket, object, doReturnUrl }) =>
+    putObject: ({ bucket, object, useSignedUrl }) =>
       Promise.resolve({ ok: true, url: "not.a.url" }),
   });
 
   const err = await adapter.putObject({
     bucket: "foo",
     object: "bar.jpg",
-    doReturnUrl: true,
+    useSignedUrl: true,
   }).catch(() => ({ ok: false }));
 
   assert(!err.ok);
@@ -205,7 +205,7 @@ Deno.test("validate putObject signedUrl - no url in return", async () => {
   const err = await adapter.putObject({
     bucket: "foo",
     object: "bar.jpg",
-    doReturnUrl: true,
+    useSignedUrl: true,
   }).catch(() => ({ ok: false }));
 
   assert(!err.ok);

--- a/packages/port-storage/mod_test.js
+++ b/packages/port-storage/mod_test.js
@@ -1,5 +1,212 @@
-import { assert } from "./dev_deps.js";
+// deno-lint-ignore-file no-unused-vars
+import { assert, Buffer } from "./dev_deps.js";
 
-Deno.test("storage port tests", () => {
-  assert(true);
+import { storage as storagePort } from "./mod.js";
+
+const wrap = {
+  makeBucket: (name) => Promise.resolve({ ok: true }),
+  removeBucket: (name) => Promise.resolve({ ok: true }),
+  listBuckets: () => Promise.resolve({ ok: true, buckets: ["foo"] }),
+  putObject: ({ bucket, object, stream }) => Promise.resolve({ ok: true }),
+  removeObject: ({ bucket, object }) => Promise.resolve({ ok: true }),
+  getObject: ({ bucket, object }) => Promise.resolve({ ok: true }),
+  listObjects: ({ bucket, prefix }) =>
+    Promise.resolve({ ok: true, objects: ["foo.jpg"] }),
+};
+
+let adapter = storagePort(wrap);
+
+Deno.test("validate adapter", async () => {
+  const results = await Promise.all([
+    adapter.makeBucket("foo"),
+    adapter.removeBucket("foo"),
+    adapter.listBuckets(),
+    adapter.putObject({
+      bucket: "foo",
+      object: "bar.jpg",
+      stream: new Buffer(new Uint8Array(4).buffer),
+    }),
+    adapter.removeObject({
+      bucket: "foo",
+      object: "bar.jpg",
+    }),
+    adapter.getObject({
+      bucket: "foo",
+      object: "bar.jpg",
+    }),
+    adapter.listObjects({
+      bucket: "foo",
+      prefix: "bar.jpg",
+    }),
+  ])
+    .then((_) => ({ ok: true }))
+    .catch((_) => {
+      console.log(_);
+      return ({ ok: false });
+    });
+
+  assert(results.ok);
+});
+
+Deno.test("validate putObject - always validate 'bucket' and 'object' params", async () => {
+  let err = await adapter.putObject({
+    bucket: "foo",
+    no_object: "bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+
+  err = await adapter.putObject({
+    no_bucket: "foo",
+    object: "bar.jpg",
+    doReturnUrl: true,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+});
+
+Deno.test("validate putObject upload", async () => {
+  // happy
+  const res = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  });
+
+  assert(res.ok);
+  assert(!res.url);
+});
+
+Deno.test("validate putObject upload - no stream", async () => {
+  // no stream
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+});
+
+Deno.test("validate putObject upload - conflicting params", async () => {
+  // conflicting params by passing both doReturnUrl: true and stream
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+    doReturnUrl: true,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+});
+
+Deno.test("validate putObject upload - invalid return", async () => {
+  // invalid return
+  adapter = storagePort({
+    ...wrap,
+    putObject: ({ bucket, object, doReturnUrl }) =>
+      Promise.resolve({ ok: true, url: "https://foo.ar" }),
+  });
+
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+
+  // cleanup
+  adapter = storagePort(wrap);
+});
+
+Deno.test("validate putObject signedUrl", async () => {
+  adapter = storagePort({
+    ...wrap,
+    putObject: ({ bucket, object, doReturnUrl }) =>
+      Promise.resolve({ ok: true, url: "https://foo.ar" }),
+  });
+
+  // happy
+  const res = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    doReturnUrl: true,
+  });
+
+  assert(res.ok);
+  assert(res.url);
+
+  // cleanup
+  adapter = storagePort(wrap);
+});
+
+Deno.test("validate putObject signedUrl - invalid doReturnUrl false", async () => {
+  adapter = storagePort({
+    ...wrap,
+    putObject: ({ bucket, object, doReturnUrl }) =>
+      Promise.resolve({ ok: true, url: "https://foo.ar" }),
+  });
+
+  // doReturnUrl false
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    doReturnUrl: false,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+
+  // cleanup
+  adapter = storagePort(wrap);
+});
+
+Deno.test("validate putObject signedUrl - conflicting params", async () => {
+  adapter = storagePort({
+    ...wrap,
+    putObject: ({ bucket, object, doReturnUrl }) =>
+      Promise.resolve({ ok: true, url: "https://foo.ar" }),
+  });
+
+  // conflicting params by passing both doReturnUrl: true and stream
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+    doReturnUrl: true,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+
+  // cleanup
+  adapter = storagePort(wrap);
+});
+
+Deno.test("validate putObject signedUrl - invalid url in return", async () => {
+  adapter = storagePort({
+    ...wrap,
+    putObject: ({ bucket, object, doReturnUrl }) =>
+      Promise.resolve({ ok: true, url: "not.a.url" }),
+  });
+
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    doReturnUrl: true,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+
+  // cleanup
+  adapter = storagePort(wrap);
+});
+
+Deno.test("validate putObject signedUrl - no url in return", async () => {
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    doReturnUrl: true,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
 });

--- a/packages/port-storage/scripts/test.sh
+++ b/packages/port-storage/scripts/test.sh
@@ -2,4 +2,4 @@
 
 deno lint && \
 deno fmt --check && \
-deno test
+deno test --no-check


### PR DESCRIPTION
This PR makes it such that `putObject` supports both of the following function schemas:

```ts
type PutObjectUploadSchema = ({ bucket: string, object: string, stream: Buffer, doReturnUrl?: false }) => Promise<{ ok: boolean }>
type PutObjectSignedUrlSchema = ({ bucket: string, object: string, doReturnUrl: true }) => Promise<{ ok: boolean, url: UrlString }>
```

If `stream` is provided, `doReturnUrl` must be `falsey`, and `putObject` will need to do a file upload and not return a signed url. If `doReturnUrl` is true, `stream` must not be provided, and a signed url must be returned.

We can make `doReturnUrl` be anything, I just picked a name to work with. We can change if we have a better name for it. Maybe `doReturnSignedUrl`?

Also fixed a little bug on `listBuckets` that I discovered when writing a catch all test for the port.

## Details

I was not able to use a [Zod Union](https://www.npmjs.com/package/zod#unions) of the function schemas. Instead, I was able to use a `union` of the two possible input arg schemas for `putObject`. This validates shared fields present in both function schemas ie. `bucket` and `object`, and then also prevents issues such as conflicting/ambiguous args ie. providing both a `stream` and `doReturnUrl: true` or `doReturnUrl: false` and no `stream`

From there, we know the input args are valid for _one_ of the function schemas, but Zod isn't smart enough to know which schema it should use to check the return value. So we check if `doReturnUrl` is provided. If it is, then we use the `PutObjectSignedUrlSchema` to validate args and the return. Otherwise, we use `PutObjectUploadSchema`. This seems to work really well, as I added some pretty exhaustive tests for `putObject` that check for proper validation, and that there isn't any chance for the input args to be ambiguous.

In general, the strategy that seemed to work was:
1. use a function schema with a union of the arg schemas (if there are shared arg fields), to validate the shared args
2. determine which overload is being used and use _that_ function schema for end to end validation.