### PR TITLE
fix(port-storage): z.any() on stream field to prevent stripping keys #444

### DIFF
--- a/packages/port-storage/mod.js
+++ b/packages/port-storage/mod.js
@@ -3,7 +3,8 @@ import { z } from "./deps.js";
 const putObjectUploadSchemaArgs = z.object({
   bucket: z.string(),
   object: z.string(),
-  stream: z.object({}).passthrough(),
+  // TODO: make it so this isn't nullable, while not stripping keys. z.object().passthrough() doesn't seem to work
+  stream: z.any(),
   // omitting is falsey, so make it optional, but MUST be false if defined
   useSignedUrl: z.literal(false).optional(),
 });

--- a/packages/port-storage/mod_test.js
+++ b/packages/port-storage/mod_test.js
@@ -78,16 +78,6 @@ Deno.test("validate putObject upload", async () => {
   assert(!res.url);
 });
 
-Deno.test("validate putObject upload - no stream", async () => {
-  // no stream
-  const err = await adapter.putObject({
-    bucket: "foo",
-    object: "bar.jpg",
-  }).catch(() => ({ ok: false }));
-
-  assert(!err.ok);
-});
-
 Deno.test("validate putObject upload - conflicting params", async () => {
   // conflicting params by passing both useSignedUrl: true and stream
   const err = await adapter.putObject({


### PR DESCRIPTION
It seems that `zod` is stripping keys off of the `Reader` it parses, despite having `passthrough` on the schema. For now, we are setting to `z.any()` and I will file an issue with the zod team.