### PR TITLE
fix: update all ports to support success + error union response #468

### DIFF
--- a/packages/port-cache/deps.js
+++ b/packages/port-cache/deps.js
@@ -1,2 +1,2 @@
 // runtime dependencies here
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-cache/mod.js
+++ b/packages/port-cache/mod.js
@@ -1,6 +1,40 @@
 import { z } from "./deps.js";
 
 /**
+ * The hyper response schema. MOST adapter methods return this shape.
+ * The ones that do not will be refactored to do so in upcoming major releases
+ *
+ * basically, there are two distinct types, each identifiable
+ * by the ok field. This is precisely the use case for Zod's discriminated Union
+ * Otherwise, all fields would be optional which isn't much of a schema
+ *
+ * See https://github.com/colinhacks/zod#discriminated-unions
+ * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
+ * for now, just using a regular union :(
+ * TODO: use discriminated when issue above is fixed
+ *
+ * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
+ * ok: true is always parsed
+ */
+const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
+  z.union([
+    // ok: true
+    schema.extend({
+      ok: z.literal(true),
+      // TODO: These two fields ought not come back for ok: true responses
+      // but are kept for backwards compatibility.
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+    // ok: false aka. HyperErr
+    z.object({
+      ok: z.literal(false),
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+  ]);
+
+/**
  * @param {function} adapter - implementation detail for this port
  * @param {object} env - environment settings for the adapter
  */
@@ -10,24 +44,26 @@ export function cache(adapter) {
     index: z.function()
       .args()
       .returns(
-        z.promise(z.string().array()),
+        // TODO: this needs to follow the hyper response format.
+        z.promise(z.union([
+          z.string().array(),
+          hyperResSchema(z.object({
+            caches: z.string().array(),
+          })),
+        ])),
       ),
     createStore: z.function()
       .args(z.string())
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
-          }),
+          hyperResSchema(),
         ),
       ),
     destroyStore: z.function()
       .args(z.string())
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
-          }),
+          hyperResSchema(),
         ),
       ),
     createDoc: z.function()
@@ -39,10 +75,7 @@ export function cache(adapter) {
       }))
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
-            error: z.string().optional(),
-          }),
+          hyperResSchema(),
         ),
       ),
     getDoc: z.function()
@@ -52,13 +85,12 @@ export function cache(adapter) {
       }))
       .returns(
         z.promise(
+          // TODO: this needs to follow the hyper response format.
           z.union([
-            z.object({
-              ok: z.boolean(),
-              status: z.number().optional(),
-              msg: z.string(),
-            }),
             z.object({}).passthrough(),
+            hyperResSchema(z.object({
+              doc: z.object({}).passthrough(),
+            })),
           ]),
         ),
       ),
@@ -71,10 +103,7 @@ export function cache(adapter) {
       }))
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
-            error: z.string().optional(),
-          }),
+          hyperResSchema(),
         ),
       ),
     deleteDoc: z.function()
@@ -84,10 +113,7 @@ export function cache(adapter) {
       }))
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
-            error: z.string().optional(),
-          }),
+          hyperResSchema(),
         ),
       ),
     listDocs: z.function()
@@ -97,12 +123,11 @@ export function cache(adapter) {
       }))
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
+          hyperResSchema(z.object({
             docs: z.array(
-              z.any(),
+              z.any(), // TODO: should this be z.object({}).passthrough() ?
             ),
-          }),
+          })),
         ),
       ),
   });

--- a/packages/port-cache/mod.js
+++ b/packages/port-cache/mod.js
@@ -8,16 +8,11 @@ import { z } from "./deps.js";
  * by the ok field. This is precisely the use case for Zod's discriminated Union
  * Otherwise, all fields would be optional which isn't much of a schema
  *
- * See https://github.com/colinhacks/zod#discriminated-unions
- * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
- * for now, just using a regular union :(
- * TODO: use discriminated when issue above is fixed
- *
  * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
  * ok: true is always parsed
  */
 const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
-  z.union([
+  z.discriminatedUnion("ok", [
     // ok: true
     schema.extend({
       ok: z.literal(true),

--- a/packages/port-crawler/deps.js
+++ b/packages/port-crawler/deps.js
@@ -1,2 +1,2 @@
 // runtime dependencies here
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-crawler/mod.js
+++ b/packages/port-crawler/mod.js
@@ -1,5 +1,39 @@
 import { z } from "./deps.js";
 
+/**
+ * The hyper response schema. MOST adapter methods return this shape.
+ * The ones that do not will be refactored to do so in upcoming major releases
+ *
+ * basically, there are two distinct types, each identifiable
+ * by the ok field. This is precisely the use case for Zod's discriminated Union
+ * Otherwise, all fields would be optional which isn't much of a schema
+ *
+ * See https://github.com/colinhacks/zod#discriminated-unions
+ * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
+ * for now, just using a regular union :(
+ * TODO: use discriminated when issue above is fixed
+ *
+ * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
+ * ok: true is always parsed
+ */
+const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
+  z.union([
+    // ok: true
+    schema.extend({
+      ok: z.literal(true),
+      // TODO: These two fields ought not come back for ok: true responses
+      // but are kept for backwards compatibility.
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+    // ok: false aka. HyperErr
+    z.object({
+      ok: z.literal(false),
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+  ]);
+
 const CrawlerDoc = z.object({
   id: z.string().optional(), // unique identifier {app}-{name}
   app: z.string(),
@@ -16,30 +50,42 @@ const CrawlerDoc = z.object({
   notify: z.string().url(), // url to notify when job is complete
 });
 
+// TODO: this needs to follow the hyper response format.
+const GetResponse = z.union([
+  CrawlerDoc,
+  hyperResSchema(z.object({
+    doc: CrawlerDoc,
+  })),
+]);
+
 const Port = z.object({
   get: z.function()
     .args(z.object({
       app: z.string(),
       name: z.string(),
     }))
-    .returns(z.promise(CrawlerDoc)),
+    .returns(z.promise(GetResponse)),
   upsert: z.function()
     .args(CrawlerDoc)
-    .returns(z.promise(z.object({
-      ok: z.boolean(),
-    }))),
+    .returns(z.promise(hyperResSchema())),
   start: z.function()
     .args(z.object({
       app: z.string(),
       name: z.string(),
     }))
-    .returns(z.promise(z.object({ ok: z.boolean() }))),
+    .returns(
+      z.promise(hyperResSchema()),
+    ),
   "delete": z.function()
     .args(z.object({
       app: z.string(),
       name: z.string(),
     }))
-    .returns(z.promise(z.object({ ok: z.boolean() }))),
+    .returns(
+      z.promise(
+        hyperResSchema(),
+      ),
+    ),
 });
 
 export function crawler(adapter) {

--- a/packages/port-crawler/mod.js
+++ b/packages/port-crawler/mod.js
@@ -8,16 +8,11 @@ import { z } from "./deps.js";
  * by the ok field. This is precisely the use case for Zod's discriminated Union
  * Otherwise, all fields would be optional which isn't much of a schema
  *
- * See https://github.com/colinhacks/zod#discriminated-unions
- * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
- * for now, just using a regular union :(
- * TODO: use discriminated when issue above is fixed
- *
  * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
  * ok: true is always parsed
  */
 const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
-  z.union([
+  z.discriminatedUnion("ok", [
     // ok: true
     schema.extend({
       ok: z.literal(true),

--- a/packages/port-data/deps.js
+++ b/packages/port-data/deps.js
@@ -1,2 +1,2 @@
 // runtime dependencies here
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-data/mod.js
+++ b/packages/port-data/mod.js
@@ -1,16 +1,54 @@
 import { z } from "./deps.js";
 
 /**
+ * The hyper response schema. MOST adapter methods return this shape.
+ * The ones that do not will be refactored to do so in upcoming major releases
+ *
+ * basically, there are two distinct types, each identifiable
+ * by the ok field. This is precisely the use case for Zod's discriminated Union
+ * Otherwise, all fields would be optional which isn't much of a schema
+ *
+ * See https://github.com/colinhacks/zod#discriminated-unions
+ * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
+ * for now, just using a regular union :(
+ * TODO: use discriminated when issue above is fixed
+ *
+ * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
+ * ok: true is always parsed
+ */
+const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
+  z.union([
+    // ok: true
+    schema.extend({
+      ok: z.literal(true),
+      // TODO: These two fields ought not come back for ok: true responses
+      // but are kept for backwards compatibility.
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+    // ok: false aka. HyperErr
+    z.object({
+      ok: z.literal(false),
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+  ]);
+
+/**
  * @param {function} adapter - implementation detail for this port
  * @param {object} env - environment settings for the adapter
  */
 export function data(adapter) {
   const Port = z.object({
     createDatabase: z.function().args(z.string()).returns(
-      z.promise(z.object({ ok: z.boolean() })),
+      z.promise(
+        hyperResSchema(),
+      ),
     ),
     removeDatabase: z.function().args(z.string()).returns(
-      z.promise(z.object({ ok: z.boolean() })),
+      z.promise(
+        hyperResSchema(),
+      ),
     ),
     createDocument: z.function()
       .args(z.object({
@@ -18,28 +56,37 @@ export function data(adapter) {
         id: z.string(),
         doc: z.any(),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
+      .returns(z.promise(
+        hyperResSchema(
+          z.object({
+            id: z.string(),
+          }),
+        ),
+      )),
+    retrieveDocument: z.function()
+      .args(z.object({
+        db: z.string(),
         id: z.string(),
-      }))),
-    retrieveDocument: z.function().args(z.object({
-      db: z.string(),
-      id: z.string(),
-    })).returns(z.promise(z.any())),
+        // TODO: this needs to follow the hyper response format.
+      })).returns(z.promise(z.any())),
     updateDocument: z.function()
       .args(z.object({
         db: z.string(),
         id: z.string(),
         doc: z.object(),
+        // TODO: this needs to follow the hyper response format.
       })).returns(z.promise(z.any())),
     removeDocument: z.function()
       .args(z.object({
         db: z.string(),
         id: z.string(),
-      })).returns(z.promise(z.object({
-        ok: z.boolean(),
-        id: z.string(),
-      }))),
+      })).returns(z.promise(
+        hyperResSchema(
+          z.object({
+            id: z.string(),
+          }),
+        ),
+      )),
     listDocuments: z.function()
       .args(z.object({
         db: z.string(),
@@ -48,10 +95,13 @@ export function data(adapter) {
         endkey: z.string().optional(),
         keys: z.string().optional(),
         descending: z.boolean().optional(),
-      })).returns(z.promise(z.object({
-        ok: z.boolean(),
-        docs: z.array(z.any()),
-      }))),
+      })).returns(z.promise(
+        hyperResSchema(
+          z.object({
+            docs: z.array(z.any()),
+          }),
+        ),
+      )),
     queryDocuments: z.function()
       .args(z.object({
         db: z.string(),
@@ -65,32 +115,35 @@ export function data(adapter) {
           use_index: z.string().optional(),
         }),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        docs: z.array(z.any()),
-      }))),
+      .returns(z.promise(
+        hyperResSchema(
+          z.object({
+            docs: z.array(z.any()),
+          }),
+        ),
+      )),
     indexDocuments: z.function()
       .args(z.object({
         db: z.string(),
         name: z.string(),
         fields: z.array(z.string()),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     bulkDocuments: z.function()
       .args(z.object({
         db: z.string(),
         docs: z.array(z.any()),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        results: z.array(z.object({
-          ok: z.boolean(),
-          id: z.string(),
-        })),
-      }))),
+      .returns(z.promise(
+        hyperResSchema(
+          z.object({
+            results: z.array(z.object({
+              ok: z.boolean(),
+              id: z.string(),
+            })),
+          }),
+        ),
+      )),
   });
   const instance = Port.parse(adapter);
   instance.createDatabase = Port.shape.createDatabase.validate(

--- a/packages/port-data/mod.js
+++ b/packages/port-data/mod.js
@@ -8,16 +8,11 @@ import { z } from "./deps.js";
  * by the ok field. This is precisely the use case for Zod's discriminated Union
  * Otherwise, all fields would be optional which isn't much of a schema
  *
- * See https://github.com/colinhacks/zod#discriminated-unions
- * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
- * for now, just using a regular union :(
- * TODO: use discriminated when issue above is fixed
- *
  * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
  * ok: true is always parsed
  */
 const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
-  z.union([
+  z.discriminatedUnion("ok", [
     // ok: true
     schema.extend({
       ok: z.literal(true),

--- a/packages/port-hooks/deps.js
+++ b/packages/port-hooks/deps.js
@@ -1,2 +1,2 @@
 // runtime dependencies here
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-queue/deps.js
+++ b/packages/port-queue/deps.js
@@ -1,1 +1,1 @@
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-queue/mod.js
+++ b/packages/port-queue/mod.js
@@ -1,6 +1,46 @@
 import { z } from "./deps.js";
 
-const QueueListResponse = z.string().array();
+/**
+ * The hyper response schema. MOST adapter methods return this shape.
+ * The ones that do not will be refactored to do so in upcoming major releases
+ *
+ * basically, there are two distinct types, each identifiable
+ * by the ok field. This is precisely the use case for Zod's discriminated Union
+ * Otherwise, all fields would be optional which isn't much of a schema
+ *
+ * See https://github.com/colinhacks/zod#discriminated-unions
+ * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
+ * for now, just using a regular union :(
+ * TODO: use discriminated when issue above is fixed
+ *
+ * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
+ * ok: true is always parsed
+ */
+const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
+  z.union([
+    // ok: true
+    schema.extend({
+      ok: z.literal(true),
+      // TODO: These two fields ought not come back for ok: true responses
+      // but are kept for backwards compatibility.
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+    // ok: false aka. HyperErr
+    z.object({
+      ok: z.literal(false),
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+  ]);
+
+const QueueListResponse = z.union([
+  // TODO: this needs to follow the hyper response format
+  z.string().array(),
+  hyperResSchema(z.object({
+    queues: z.string().array(),
+  })),
+]);
 
 const QueueCreateInput = z.object({
   name: z.string(),
@@ -8,11 +48,7 @@ const QueueCreateInput = z.object({
   secret: z.string().max(100).optional(),
 });
 
-const QueueResponse = z.object({
-  ok: z.boolean(),
-  msg: z.string().optional(),
-  status: z.number().optional(),
-});
+const QueueResponse = hyperResSchema();
 
 const QueuePostInput = z.object({
   name: z.string(),
@@ -24,11 +60,9 @@ const QueueGetInput = z.object({
   status: z.enum(["READY", "ERROR"]),
 });
 
-const JobsResponse = z.object({
-  ok: z.boolean(),
+const JobsResponse = hyperResSchema(z.object({
   jobs: z.array(z.object({}).passthrough()).optional(),
-  status: z.number().optional(),
-});
+}));
 
 const JobInput = z.object({
   name: z.string(),
@@ -41,7 +75,7 @@ const QueuePort = z.object({
     .returns(z.promise(QueueListResponse)),
   create: z.function()
     .args(QueueCreateInput)
-    .returns(z.promise(QueueResponse)),
+    .returns(z.promise(hyperResSchema())),
   delete: z.function()
     .args(z.string())
     .returns(z.promise(QueueResponse)),

--- a/packages/port-queue/mod.js
+++ b/packages/port-queue/mod.js
@@ -8,16 +8,11 @@ import { z } from "./deps.js";
  * by the ok field. This is precisely the use case for Zod's discriminated Union
  * Otherwise, all fields would be optional which isn't much of a schema
  *
- * See https://github.com/colinhacks/zod#discriminated-unions
- * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
- * for now, just using a regular union :(
- * TODO: use discriminated when issue above is fixed
- *
  * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
  * ok: true is always parsed
  */
 const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
-  z.union([
+  z.discriminatedUnion("ok", [
     // ok: true
     schema.extend({
       ok: z.literal(true),

--- a/packages/port-search/deps.js
+++ b/packages/port-search/deps.js
@@ -1,2 +1,2 @@
 // runtime dependencies here
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-search/mod.js
+++ b/packages/port-search/mod.js
@@ -1,5 +1,39 @@
 import { z } from "./deps.js";
 
+/**
+ * The hyper response schema. MOST adapter methods return this shape.
+ * The ones that do not will be refactored to do so in upcoming major releases
+ *
+ * basically, there are two distinct types, each identifiable
+ * by the ok field. This is precisely the use case for Zod's discriminated Union
+ * Otherwise, all fields would be optional which isn't much of a schema
+ *
+ * See https://github.com/colinhacks/zod#discriminated-unions
+ * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
+ * for now, just using a regular union :(
+ * TODO: use discriminated when issue above is fixed
+ *
+ * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
+ * ok: true is always parsed
+ */
+const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
+  z.union([
+    // ok: true
+    schema.extend({
+      ok: z.literal(true),
+      // TODO: These two fields ought not come back for ok: true responses
+      // but are kept for backwards compatibility.
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+    // ok: false aka. HyperErr
+    z.object({
+      ok: z.literal(false),
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+  ]);
+
 export function search(adapter) {
   const Port = z.object({
     // add port methods
@@ -8,55 +42,43 @@ export function search(adapter) {
         index: z.string(),
         mappings: z.any(),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     deleteIndex: z.function()
       .args(z.string())
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     indexDoc: z.function()
       .args(z.object({
         index: z.string(),
         key: z.string(), // remember to invalidate if key === query
         doc: z.any(),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     updateDoc: z.function()
       .args(z.object({
         index: z.string(),
         key: z.string(),
         doc: z.any(),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     getDoc: z.function()
       .args(z.object({
         index: z.string(),
         key: z.string(),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        key: z.string(),
-        doc: z.any(),
-      }))),
+      .returns(z.promise(
+        hyperResSchema(
+          z.object({
+            key: z.string(),
+            doc: z.any(),
+          }),
+        ),
+      )),
     removeDoc: z.function()
       .args(z.object({
         index: z.string(),
         key: z.string(),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
 
     bulk: z.function()
       .args(z.object({
@@ -67,10 +89,11 @@ export function search(adapter) {
       }))
       .returns(
         z.promise(
-          z.object({
-            ok: z.boolean(),
-            results: z.array(z.any()),
-          }),
+          hyperResSchema(
+            z.object({
+              results: z.array(z.any()),
+            }),
+          ),
         ),
       ),
     query: z.function()
@@ -82,10 +105,13 @@ export function search(adapter) {
           filter: z.any().optional(),
         }),
       }))
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        matches: z.array(z.any()),
-      }))),
+      .returns(z.promise(
+        hyperResSchema(
+          z.object({
+            matches: z.array(z.any()),
+          }),
+        ),
+      )),
   });
 
   const instance = Port.parse(adapter);

--- a/packages/port-search/mod.js
+++ b/packages/port-search/mod.js
@@ -8,16 +8,11 @@ import { z } from "./deps.js";
  * by the ok field. This is precisely the use case for Zod's discriminated Union
  * Otherwise, all fields would be optional which isn't much of a schema
  *
- * See https://github.com/colinhacks/zod#discriminated-unions
- * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
- * for now, just using a regular union :(
- * TODO: use discriminated when issue above is fixed
- *
  * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
  * ok: true is always parsed
  */
 const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
-  z.union([
+  z.discriminatedUnion("ok", [
     // ok: true
     schema.extend({
       ok: z.literal(true),

--- a/packages/port-storage/deps.js
+++ b/packages/port-storage/deps.js
@@ -1,2 +1,2 @@
 // runtime dependencies here
-export * as z from "https://cdn.skypack.dev/zod@3.11.6";
+export * as z from "https://cdn.skypack.dev/zod@3.12.1";

--- a/packages/port-storage/mod.js
+++ b/packages/port-storage/mod.js
@@ -1,16 +1,58 @@
 import { z } from "./deps.js";
 
+/**
+ * The hyper response schema. MOST adapter methods return this shape.
+ * The ones that do not will be refactored to do so in upcoming major releases
+ *
+ * basically, there are two distinct types, each identifiable
+ * by the ok field. This is precisely the use case for Zod's discriminated Union
+ * Otherwise, all fields would be optional which isn't much of a schema
+ *
+ * See https://github.com/colinhacks/zod#discriminated-unions
+ * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
+ * for now, just using a regular union :(
+ * TODO: use discriminated when issue above is fixed
+ *
+ * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
+ * ok: true is always parsed
+ */
+const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
+  z.union([
+    // ok: true
+    schema.extend({
+      ok: z.literal(true),
+      // TODO: These two fields ought not come back for ok: true responses
+      // but are kept for backwards compatibility.
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+    // ok: false aka. HyperErr
+    z.object({
+      ok: z.literal(false),
+      msg: z.string().optional(),
+      status: z.number().optional(),
+    }),
+  ]);
+
 const putObjectUploadSchemaArgs = z.object({
   bucket: z.string(),
   object: z.string(),
-  // TODO: make it so this isn't nullable, while not stripping keys. z.object().passthrough() doesn't seem to work
-  stream: z.any(),
+  stream: z.any().refine(
+    (val) => val != null, // intentionally not "double equals" to catch undefined and null
+    { message: "stream must be defined" },
+  ),
   // omitting is falsey, so make it optional, but MUST be false if defined
   useSignedUrl: z.literal(false).optional(),
 });
 const putObjectUploadSchema = z.function()
   .args(putObjectUploadSchemaArgs)
-  .returns(z.promise(z.object({ ok: z.boolean(), url: z.void() })));
+  .returns(
+    z.promise(
+      hyperResSchema(z.object({
+        url: z.void(),
+      })),
+    ),
+  );
 
 const putObjectSignedUrlSchemaArgs = z.object({
   bucket: z.string(),
@@ -21,7 +63,13 @@ const putObjectSignedUrlSchemaArgs = z.object({
 });
 const putObjectSignedUrlSchema = z.function()
   .args(putObjectSignedUrlSchemaArgs)
-  .returns(z.promise(z.object({ ok: z.boolean(), url: z.string().url() })));
+  .returns(
+    z.promise(
+      hyperResSchema(z.object({
+        url: z.string().url(),
+      })),
+    ),
+  );
 
 /**
  * @param {function} adapter - implementation detail for this port
@@ -31,22 +79,17 @@ export function storage(adapter) {
   const Port = z.object({
     makeBucket: z.function()
       .args(z.string())
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     removeBucket: z.function()
       .args(z.string())
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        msg: z.string().optional(),
-      }))),
+      .returns(z.promise(hyperResSchema())),
     listBuckets: z.function()
       .args()
-      .returns(z.promise(z.object({
-        ok: z.boolean(),
-        buckets: z.array(z.string()),
-      }))),
+      .returns(z.promise(
+        hyperResSchema(z.object({
+          buckets: z.array(z.string()),
+        })),
+      )),
     putObject: z.function()
       .args(z.union([
         putObjectUploadSchemaArgs,
@@ -59,7 +102,7 @@ export function storage(adapter) {
         bucket: z.string(),
         object: z.string(),
       }))
-      .returns(z.promise(z.object({ ok: z.boolean() }))),
+      .returns(z.promise(hyperResSchema())),
     getObject: z.function()
       .args(z.object({
         bucket: z.string(),
@@ -71,7 +114,14 @@ export function storage(adapter) {
         bucket: z.string(),
         prefix: z.string().optional(),
       }))
-      .returns(z.promise(z.any())),
+      .returns(z.promise(
+        z.union([
+          z.any(),
+          hyperResSchema(z.object({
+            objects: z.any(),
+          })),
+        ]),
+      )),
   });
 
   const instance = Port.parse(adapter);

--- a/packages/port-storage/mod.js
+++ b/packages/port-storage/mod.js
@@ -8,16 +8,11 @@ import { z } from "./deps.js";
  * by the ok field. This is precisely the use case for Zod's discriminated Union
  * Otherwise, all fields would be optional which isn't much of a schema
  *
- * See https://github.com/colinhacks/zod#discriminated-unions
- * NOTE: using discriminated union is blocked by https://github.com/colinhacks/zod/issues/965
- * for now, just using a regular union :(
- * TODO: use discriminated when issue above is fixed
- *
  * @argument {z.ZodSchema} - the schema for the success response, it is extended to ensure
  * ok: true is always parsed
  */
 const hyperResSchema = (schema = z.object({ ok: z.boolean() })) =>
-  z.union([
+  z.discriminatedUnion("ok", [
     // ok: true
     schema.extend({
       ok: z.literal(true),

--- a/packages/port-storage/mod_test.js
+++ b/packages/port-storage/mod_test.js
@@ -78,6 +78,16 @@ Deno.test("validate putObject upload", async () => {
   assert(!res.url);
 });
 
+Deno.test("validate putObject upload - nil stream", async () => {
+  const err = await adapter.putObject({
+    bucket: "foo",
+    object: "bar.jpg",
+    stream: null,
+  }).catch(() => ({ ok: false }));
+
+  assert(!err.ok);
+});
+
 Deno.test("validate putObject upload - conflicting params", async () => {
   // conflicting params by passing both useSignedUrl: true and stream
   const err = await adapter.putObject({


### PR DESCRIPTION
TL;DR: there shouldn't be any breaking changes in this PR, besides removing the unused `error` fields on some Cache port methods. Everything else should be backwards compatible. Not a lot of code changes (most of the diff is the duplicated utility), but need to explain my reasoning.

---

Previously, adapters would send back resolved promises for successful responses and rejected promises for error responses. With #468, that paradigm has shifted, such that an _unhandled_ exceptions returns as a rejected promise and a _handled_ exception should returned as a resolved promise.

Zod schemas wrap each adapter method, that validate the return type of _resolved_ responses. Since errors were previously not resolved responses, these were not validated. Now they run through the zod schema validation flow, which is what we want, but introduces some necessary changes:

## `status` and `msg`

`msg` was present on some methods on some ports, but not all of them. `status` was less present. Firstly, because hyper convention is `msg` and `status` only come back for error responses, and the zod schema is not used to validate rejected promises, these fields on the schema were superfluous. Now with the new error convention, they are not superfluous, but a new issue arises: **With object schemas, Zod will parse a value against a schema, then STRIP extraneous fields. This meant that `status` and `msg` had to be added explicitly to each return type schema on each port method.

## all optional fields on return types

Because the resolve/reject promise boundary separated the success and error responses before, this wasn't an issue. Now both success and error responses can come back as a resolved Promise, and thereby are parsed by zod. If we were to try and encapsulate this into a _single_ Zod object schema, say for `queryDocuments`, effectively all fields on the return schema, besides `ok`, would have to be `optional()`:

```
z.object({
  ok: z.boolean(),
  msg: z.string().optional(),  <-- won't come back on valid success response so must be optional
  status: z.number().optional(), <-- won't come back on valid success response so must be optional
  docs: z.array(z.any()).optional(), <-- won't come back on valid error response so must be optional
}),
```

This isn't particularly useful, for validation. Ideally we would like some fields to be required if `ok === true` and other fields to be required if `ok === false`.

## The solution: Zod Discriminated Union Response

Zod introduced a new feature in `3.12.0` called [discriminated unions](https://github.com/colinhacks/zod#discriminated-unions) which is precisely what we need. However, due to https://github.com/colinhacks/zod/issues/965 we cannot use that version just yet. For now, `z.union` will suffice.

We use `zod.union` to represent the possible return types of each adapter method. I've created a utility called `hyperResSchema` which enforces the union between a "success" response and a "hyper error" response. This allows each port to validate each _type_ of response, without needing to make each field optional. I've duped this util across ports. perhaps eventually, we move it into `hyper-utils`

## hyper responses everywhere

Eventually, we want each port method to return a "hyper response", that is `{ ok: boolean, .... }`. There are some apis that do not follow this convention. But we would like ways to adapters to incrementally move to this convention without breaking validation. For this, I updated the following methods such that the schema supports the current return type, and a "hyper response" return type:

- Storage Port `ListObjects`: can be current `z.string().any()` or hyper response with `{ objects: z.string().any() }` 
- Queue Port `Index`: can be current `z.string().any()` or hyper response with `{ queues: z.string().any() }` 
- Crawler Port `get`: can be current `CrawlerDoc` or hyper response with `{ doc: CrawlerDoc }` 
- Cache Port `getDoc`: can be current `any()` or hyper response with `{ doc: any() }`
- Cache Port `update, delete, create`: removed optional `error` field from response (it should return a hyper error)
- Cache Port `index`: can be current `z.string().any()` or hyper response with `{ caches: z.string().any() }`

## other things I did

- Storage Port `putObject`: `stream` must now be defined (not `nil`) if `useSignedUrl` is `falsey` using suggested approach from https://github.com/colinhacks/zod/issues/925