### PR TITLE
feat(core): indicate error in event payload from core #468

### DIFF
--- a/packages/core/lib/utils/mod.js
+++ b/packages/core/lib/utils/mod.js
@@ -67,6 +67,11 @@ export const triggerEvent = (event) =>
   (data) =>
     ask(({ events }) => {
       const payload = { date: new Date().toISOString() };
+      if (isHyperErr(data)) {
+        payload.ok = false;
+        payload.status = data.status;
+        payload.msg = data.msg;
+      }
       if (data.name) payload.name = data.name;
       if (data.id) payload.id = data.id;
       if (data.type) payload.type = data.type;


### PR DESCRIPTION
Something I noticed when wiring everything up into hyper cloud. Now that events are being triggered (and logged) for all _handled_ responses from adapters, which includes handled hyper errors, it would be nice to see what events correspond to errors.

Right now, this would branch would run for both handled errors and fuzzy-mapped errors from core. I could the case for only triggering for fuzzy mapped errors ie `data.originalErr is not nil`.