### PR TITLE
fix(app-opine): sanitize resolved and rejected errors from core #482

### DIFF
--- a/packages/app-opine/deps.js
+++ b/packages/app-opine/deps.js
@@ -2,12 +2,14 @@ export { json, opine, Router } from "https://deno.land/x/opine@2.1.2/mod.ts";
 export { opineCors as cors } from "https://deno.land/x/cors@v1.2.2/mod.ts";
 export { lookup as getMimeType } from "https://deno.land/x/media_types@v2.12.2/mod.ts";
 
-export { MultipartReader } from "https://deno.land/std@0.127.0/mime/mod.ts";
-export { Buffer } from "https://deno.land/std@0.127.0/io/buffer.ts";
-export { exists } from "https://deno.land/std@0.127.0/fs/exists.ts";
+export { MultipartReader } from "https://deno.land/std@0.128.0/mime/mod.ts";
+export { Buffer } from "https://deno.land/std@0.128.0/io/buffer.ts";
+export { exists } from "https://deno.land/std@0.128.0/fs/exists.ts";
 
 export { default as helmet } from "https://cdn.skypack.dev/helmet@5.0.2";
 export * as R from "https://cdn.skypack.dev/ramda@0.28.0";
 export { default as crocks } from "https://cdn.skypack.dev/crocks@0.12.4";
+
+export { isHyperErr } from "https://x.nest.land/hyper-utils@0.1.0/hyper-err.js";
 
 //export { hyperGqlRouter } from "https://x.nest.land/hyper-app-graphql@0.3.0/router.js";

--- a/packages/app-opine/dev_deps.js
+++ b/packages/app-opine/dev_deps.js
@@ -2,5 +2,5 @@ export {
   assert,
   assertEquals,
   assertObjectMatch,
-} from "https://deno.land/std@0.127.0/testing/asserts.ts";
+} from "https://deno.land/std@0.128.0/testing/asserts.ts";
 export { superdeno } from "https://deno.land/x/superdeno@4.7.2/mod.ts";


### PR DESCRIPTION
Closes #482 

Also pulled in `isHyperErr` from `hyper-utils`