### PR TITLE
chore(core): remove id monitoring and mapping _id -> id on outbound

### DIFF
--- a/packages/core/lib/data/db.js
+++ b/packages/core/lib/data/db.js
@@ -1,19 +1,8 @@
-import { crocks, R } from "../../deps.js";
+import { R } from "../../deps.js";
 
-import {
-  apply,
-  handleHyperErr,
-  is,
-  liftFn,
-  mapId,
-  monitorIdUsage,
-  of,
-  rejectHyperErr,
-  triggerEvent,
-} from "../utils/mod.js";
+import { apply, is, of, triggerEvent } from "../utils/mod.js";
 
-const { Async } = crocks;
-const { lensProp, over, evolve, map } = R;
+const { lensProp, over } = R;
 
 const INVALID_DB_MSG = "database name is not valid";
 const INVALID_RESPONSE = "response is not valid";
@@ -34,19 +23,7 @@ export const remove = (name) =>
 export const query = (db, query) =>
   of({ db, query })
     .chain(apply("queryDocuments"))
-    .chain(triggerEvent("DATA:QUERY"))
-    .chain(liftFn((res) =>
-      rejectHyperErr(res)
-        .map((res) => {
-          res.docs.forEach(monitorIdUsage("queryDocuments - result", db));
-          return res;
-        })
-        .map(evolve({ docs: map(mapId) }))
-        .bichain(
-          handleHyperErr,
-          Async.Resolved,
-        )
-    ));
+    .chain(triggerEvent("DATA:QUERY"));
 
 export const index = (db, name, fields) =>
   of({ db, name, fields })
@@ -57,26 +34,10 @@ export const list = (db, options) =>
   of({ db, ...options })
     .map(over(lensProp("descending"), Boolean))
     .chain(apply("listDocuments"))
-    .chain(triggerEvent("DATA:LIST"))
-    .chain(liftFn((res) =>
-      rejectHyperErr(res)
-        .map((res) => {
-          res.docs.forEach(monitorIdUsage("listDocuments - result", db));
-          return res;
-        })
-        .map(evolve({ docs: map(mapId) }))
-        .bichain(
-          handleHyperErr,
-          Async.Resolved,
-        )
-    ));
+    .chain(triggerEvent("DATA:LIST"));
 
 export const bulk = (db, docs) =>
   of({ db, docs })
-    .map((args) => {
-      args.docs.forEach(monitorIdUsage("bulkDocuments - args", db));
-      return args;
-    })
     .chain(apply("bulkDocuments"))
     .chain(triggerEvent("DATA:BULK"));
 

--- a/packages/core/lib/data/db_test.js
+++ b/packages/core/lib/data/db_test.js
@@ -88,7 +88,6 @@ test(
     db.list("foo", { limit: "2" })
       .map((res) => {
         res.docs.forEach((r) => {
-          assert(r.id);
           assert(r._id);
         });
         return res;
@@ -121,7 +120,6 @@ test(
     db.query("foo", { selector: { id: "foo" } })
       .map((res) => {
         res.docs.forEach((r) => {
-          assert(r.id);
           assert(r._id);
         });
         return res;

--- a/packages/core/lib/data/doc.js
+++ b/packages/core/lib/data/doc.js
@@ -1,25 +1,13 @@
-import { crocks, cuid, R } from "../../deps.js";
-import {
-  apply,
-  handleHyperErr,
-  is,
-  liftFn,
-  mapId,
-  monitorIdUsage,
-  of,
-  rejectHyperErr,
-  triggerEvent,
-} from "../utils/mod.js";
+import { cuid, R } from "../../deps.js";
+import { apply, is, of, triggerEvent } from "../utils/mod.js";
 
-const { Async } = crocks;
-const { omit, defaultTo } = R;
+const { defaultTo } = R;
 
 // const INVALID_ID_MSG = 'doc id is not valid'
 const INVALID_RESPONSE = "response is not valid";
 
 export const create = (db, doc) =>
   of(doc)
-    .map(monitorIdUsage("createDocument - args", db))
     .map(defaultTo({}))
     .map((doc) => ({ db, id: doc._id || cuid(), doc }))
     .chain(apply("createDocument"))
@@ -29,36 +17,12 @@ export const create = (db, doc) =>
 export const get = (db, id) =>
   of({ db, id })
     .chain(apply("retrieveDocument"))
-    .chain(triggerEvent("DATA:GET"))
-    .chain(liftFn((res) =>
-      rejectHyperErr(res)
-        .map(monitorIdUsage("retrieveDocument - result", db))
-        .map(mapId)
-        .bichain(
-          handleHyperErr,
-          Async.Resolved,
-        )
-    ));
+    .chain(triggerEvent("DATA:GET"));
 
 export const update = (db, id, doc) =>
   of({ db, id, doc })
-    .map((args) => {
-      monitorIdUsage("updateDocument - args", args.db)(args.doc);
-      return args;
-    })
     .chain(apply("updateDocument"))
-    .chain(triggerEvent("DATA:UPDATE"))
-    .chain(liftFn((res) =>
-      rejectHyperErr(res)
-        // TODO: id not enforced on port. Should it be?
-        // For now, just mapping to id to match docs
-        .map(mapId)
-        .map(omit(["_id"]))
-        .bichain(
-          handleHyperErr,
-          Async.Resolved,
-        )
-    ));
+    .chain(triggerEvent("DATA:UPDATE"));
 
 export const remove = (db, id) =>
   of({ db, id })

--- a/packages/core/lib/data/doc_test.js
+++ b/packages/core/lib/data/doc_test.js
@@ -130,16 +130,3 @@ test(
   "remove document",
   fork(doc.remove("foo", "1").runWith({ svc: mock, events })),
 );
-
-test(
-  "corncob - keep outbound id and _id",
-  fork(
-    doc.get("foo", "1")
-      .map((res) => {
-        assert(res.id);
-        assert(res._id);
-        return res;
-      })
-      .runWith({ svc: mock, events }),
-  ),
-);

--- a/packages/core/lib/utils/err.js
+++ b/packages/core/lib/utils/err.js
@@ -1,15 +1,6 @@
-import {
-  crocks,
-  HyperErr,
-  isBaseHyperErr,
-  isHyperErr,
-  R,
-  z,
-} from "../../deps.js";
+import { HyperErr, isBaseHyperErr, R, z } from "../../deps.js";
 
 const { ZodError, ZodIssueCode } = z;
-
-const { Async } = crocks;
 
 const {
   compose,
@@ -265,15 +256,3 @@ export const HyperErrFrom = (err) =>
     ),
     defaultTo({ msg: "An error occurred" }),
   )(err);
-
-export const rejectHyperErr = ifElse(
-  isHyperErr,
-  Async.Rejected,
-  Async.Resolved,
-);
-
-export const handleHyperErr = ifElse(
-  isHyperErr,
-  Async.Resolved,
-  Async.Rejected,
-);

--- a/packages/core/lib/utils/mod.js
+++ b/packages/core/lib/utils/mod.js
@@ -87,24 +87,3 @@ export const triggerEvent = (event) =>
  * constructor for an AsyncReader monad
  */
 export const of = ReaderAsync.of;
-
-/**
- * Apricot: support both _id and id, incoming, and outgoing
- * Blueberry: support _id incoming, and id and _id outgoing
- */
-export const mapId = (doc) => ({
-  ...doc,
-  id: doc.id || doc._id,
-  _id: doc._id || doc.id,
-});
-
-export const monitorIdUsage = (method, db) =>
-  (doc) => {
-    if (doc && doc.id && !doc._id) {
-      console.warn(
-        `MIGRATION ALERT (${method}) on ${db}: doc with id "${doc.id}" missing _id field`,
-      );
-    }
-
-    return doc;
-  };

--- a/packages/test/data/query-documents.js
+++ b/packages/test/data/query-documents.js
@@ -78,8 +78,7 @@ export default function (data) {
       .chain(query({ type: "album" }, { fields: ["_id", "band"] }))
       .map((r) => (assertEquals(r.ok, true), r))
       .map((r) => (r.docs.forEach((doc) => assert(doc._id)), r))
-      // TODO: remove +1 in corncob
-      .map((r) => (assertEquals(keys(r.docs[0]).length, 2 + 1), r)) // +1 because _id and id are being added to result by core
+      .map((r) => (assertEquals(keys(r.docs[0]).length, 2), r))
       .chain(tearDown)
       .toPromise());
 }


### PR DESCRIPTION
Just removing code that mapped _id -> id on outbound requests

Closes #420 