### PR TITLE
feat: add support for useSignedUrl for getObject #519

### DIFF
--- a/packages/app-opine/api/storage.js
+++ b/packages/app-opine/api/storage.js
@@ -1,5 +1,5 @@
 import { Buffer, crocks, getMimeType } from "../deps.js";
-import { fork, isFile, isMultipartFormData } from "../utils.js";
+import { fork, isFile, isMultipartFormData, isTrue } from "../utils.js";
 
 const { Async } = crocks;
 
@@ -25,100 +25,114 @@ export const removeBucket = ({ params, storage }, res) =>
  * @param {*} res
  * @returns
  */
-export const putObject = (fieldName = "file") =>
-  async (req, res) => {
-    /**
-     * Ensure reader is closed, if defined, to prevent leaks
-     * in the case of a tempfile being created
-     */
-    const cleanup = (_p) =>
-      Async.fromPromise(async (res) => {
-        if (reader && typeof reader.close === "function") {
-          await reader.close();
-        }
-
-        return _p(res);
-      });
-
-    const { params, storage } = req;
-
-    let reader = undefined;
-
-    const bucket = params.name;
-    let object = "";
-    let useSignedUrl = false;
-
-    // Upload
-    if (isMultipartFormData(req.get("content-type"))) {
-      const form = req.form;
-      const file = form.files(fieldName)[0];
-      reader = file.content
-        ? new Buffer(file.content.buffer) // from memory
-        : await Deno.open(file.tempfile, { read: true }); // from tempfile if too large for memory buffer
-
-      // object is placed at root of bucket, by default
-      object = file.filename;
-
-      // object can be placed in "subdirectories within the bucket"
-      let path = form.values("path")
-        ? form.values("path")[0]
-        : params[0] || undefined; // fallback to url path, if defined, if form data path is not defined
-
-      if (path) {
-        /**
-         * The filename, from FormData file, takes precedent over any filename in path,
-         *
-         * Examples:
-         *
-         * POST /bucket/foo/bar.jpg form-data: (file: actual.jpg) will
-         * ignore `bar.jpg` and use `actual.jpg` for the filename
-         * effectively acting as POST /bucket/foo form-data: (file: actual.jpg)
-         *
-         * POST /bucket form-data: (file: actual.jpg, path: foo/bar.jpg) will
-         * ignore `bar.jpg` and use `actual.jpg` for the filename
-         * effectively acting as POST /bucket/foo form-data: (file: actual.jpg)
-         */
-        if (isFile(path)) {
-          path = path.split("/").slice(0, -1).join("/");
-        }
-
-        if (path.endsWith("/")) {
-          path = path.slice(0, -1);
-        }
-
-        object = `${path}/${object}`;
+export const putObject = (fieldName = "file") => async (req, res) => {
+  /**
+   * Ensure reader is closed, if defined, to prevent leaks
+   * in the case of a tempfile being created
+   */
+  const cleanup = (_p) =>
+    Async.fromPromise(async (res) => {
+      if (reader && typeof reader.close === "function") {
+        await reader.close();
       }
-    } else {
-      // useSignedUrl
-      useSignedUrl = true;
-      // TODO: Tyler. should we check if the object is a file name?
-      object = params[0] || undefined; // map all falsey to undefined, then Let Storage port catch
+
+      return _p(res);
+    });
+
+  const { params, storage } = req;
+
+  let reader = undefined;
+
+  const bucket = params.name;
+  let object = "";
+  let useSignedUrl = false;
+
+  // Upload
+  if (isMultipartFormData(req.get("content-type"))) {
+    const form = req.form;
+    const file = form.files(fieldName)[0];
+    reader = file.content
+      ? new Buffer(file.content.buffer) // from memory
+      : await Deno.open(file.tempfile, { read: true }); // from tempfile if too large for memory buffer
+
+    // object is placed at root of bucket, by default
+    object = file.filename;
+
+    // object can be placed in "subdirectories within the bucket"
+    let path = form.values("path")
+      ? form.values("path")[0]
+      : params[0] || undefined; // fallback to url path, if defined, if form data path is not defined
+
+    if (path) {
+      /**
+       * The filename, from FormData file, takes precedent over any filename in path,
+       *
+       * Examples:
+       *
+       * POST /bucket/foo/bar.jpg form-data: (file: actual.jpg) will
+       * ignore `bar.jpg` and use `actual.jpg` for the filename
+       * effectively acting as POST /bucket/foo form-data: (file: actual.jpg)
+       *
+       * POST /bucket form-data: (file: actual.jpg, path: foo/bar.jpg) will
+       * ignore `bar.jpg` and use `actual.jpg` for the filename
+       * effectively acting as POST /bucket/foo form-data: (file: actual.jpg)
+       */
+      if (isFile(path)) {
+        path = path.split("/").slice(0, -1).join("/");
+      }
+
+      if (path.endsWith("/")) {
+        path = path.slice(0, -1);
+      }
+
+      object = `${path}/${object}`;
     }
+  } else {
+    // useSignedUrl
+    useSignedUrl = true;
+    // TODO: Tyler. should we check if the object is a file name?
+    object = params[0] || undefined; // map all falsey to undefined, then Let Storage port catch
+  }
 
-    return fork(
-      res,
-      201,
-      storage.putObject(bucket, object, reader, useSignedUrl).bichain(
-        cleanup(Promise.reject.bind(Promise)),
-        cleanup(Promise.resolve.bind(Promise)),
-      ),
-    );
-  };
+  return fork(
+    res,
+    201,
+    storage.putObject(bucket, object, reader, useSignedUrl).bichain(
+      cleanup(Promise.reject.bind(Promise)),
+      cleanup(Promise.resolve.bind(Promise)),
+    ),
+  );
+};
 
-export const getObject = ({ params, storage }, res) =>
+export const getObject = ({ params, query, storage }, res) =>
   fork(
     res,
     200,
-    storage.getObject(params.name, params[0]).map((fileReader) => {
-      // get mime type and set response
-      const mimeType = getMimeType(params[0].split(".")[1]);
-      res.set({
-        "Content-Type": mimeType,
-        "Transfer-Encoding": "chunked",
-      });
+    /**
+     * ?useSignedUrl=true
+     */
+    storage.getObject(params.name, params[0], isTrue(query.useSignedUrl)).map(
+      (result) => {
+        /**
+         * adapter will return JSON that contains a url
+         * similar to what putObject:useSignedUrl returns
+         */
+        if (isTrue(query.useSignedUrl)) {
+          return result;
+        }
 
-      return fileReader;
-    }),
+        /**
+         * Get mime type and set response
+         */
+        const mimeType = getMimeType(params[0].split(".")[1]);
+        res.set({
+          "Content-Type": mimeType,
+          "Transfer-Encoding": "chunked",
+        });
+
+        return result;
+      },
+    ),
   );
 
 export const removeObject = ({ params, storage }, res) =>

--- a/packages/app-opine/dev_deps.js
+++ b/packages/app-opine/dev_deps.js
@@ -2,5 +2,5 @@ export {
   assert,
   assertEquals,
   assertObjectMatch,
-} from "https://deno.land/std@0.133.0/testing/asserts.ts";
+} from "https://deno.land/std@0.152.0/testing/asserts.ts";
 export { superdeno } from "https://deno.land/x/superdeno@4.8.0/mod.ts";

--- a/packages/app-opine/test/utils_test.js
+++ b/packages/app-opine/test/utils_test.js
@@ -1,7 +1,7 @@
 import { crocks } from "../deps.js";
 import { assert, assertEquals } from "../dev_deps.js";
 
-import { fork } from "../utils.js";
+import { fork, isFile, isMultipartFormData, isTrue } from "../utils.js";
 
 const { Async } = crocks;
 
@@ -17,41 +17,79 @@ const env = Deno.env.get("DENO_ENV");
 const cleanup = () =>
   env ? Deno.env.set("DENO_ENV", env) : Deno.env.delete("DENO_ENV");
 
-Deno.test("should sanitize errors on both branches", async () => {
-  Deno.env.set("DENO_ENV", "production");
+Deno.test("fork", async (t) => {
+  await t.step("should sanitize errors on both branches", async () => {
+    Deno.env.set("DENO_ENV", "production");
 
-  // resolved success
-  await fork(res, 200, Async.Resolved({ ok: true }));
-  assert(result.ok);
+    // resolved success
+    await fork(res, 200, Async.Resolved({ ok: true }));
+    assert(result.ok);
 
-  // resolved error
-  await fork(res, 200, Async.Resolved({ ok: false, originalErr: "foobar" }));
-  assertEquals(result.ok, false);
-  assert(!result.originalErr);
+    // resolved error
+    await fork(res, 200, Async.Resolved({ ok: false, originalErr: "foobar" }));
+    assertEquals(result.ok, false);
+    assert(!result.originalErr);
 
-  // rejected error (fatal)
-  await fork(res, 200, Async.Rejected({ ok: false, originalErr: "foobar" }));
-  assertEquals(result, "Internal Server Error");
+    // rejected error (fatal)
+    await fork(res, 200, Async.Rejected({ ok: false, originalErr: "foobar" }));
+    assertEquals(result, "Internal Server Error");
 
-  cleanup();
+    cleanup();
+  });
+
+  await t.step("should NOT sanitize errors on both branches", async () => {
+    Deno.env.set("DENO_ENV", "foo");
+
+    // resolved success
+    await fork(res, 200, Async.Resolved({ ok: true }));
+    assert(result.ok);
+
+    // resolved error
+    await fork(res, 200, Async.Resolved({ ok: false, originalErr: "foobar" }));
+    assertEquals(result.ok, false);
+    assert(result.originalErr);
+
+    // rejected error (fatal)
+    await fork(res, 200, Async.Rejected({ ok: false, originalErr: "foobar" }));
+    assertEquals(result.ok, false);
+    assert(result.originalErr);
+
+    cleanup();
+  });
 });
 
-Deno.test("should NOT sanitize errors on both branches", async () => {
-  Deno.env.set("DENO_ENV", "foo");
+Deno.test("isMultipartFormData", async (t) => {
+  await t.step(
+    "should return true if header indicates multipart/form-data",
+    () => {
+      assert(isMultipartFormData("multipart/form-data"));
+      assert(!isMultipartFormData("application/json"));
+      assert(!isMultipartFormData());
+    },
+  );
+});
 
-  // resolved success
-  await fork(res, 200, Async.Resolved({ ok: true }));
-  assert(result.ok);
+Deno.test("isFile", async (t) => {
+  await t.step(
+    "should return true if path points to a file",
+    () => {
+      assert(isFile("/foo.jpg"));
+      assert(!isFile("/foo"));
+      assert(!isFile());
+    },
+  );
+});
 
-  // resolved error
-  await fork(res, 200, Async.Resolved({ ok: false, originalErr: "foobar" }));
-  assertEquals(result.ok, false);
-  assert(result.originalErr);
-
-  // rejected error (fatal)
-  await fork(res, 200, Async.Rejected({ ok: false, originalErr: "foobar" }));
-  assertEquals(result.ok, false);
-  assert(result.originalErr);
-
-  cleanup();
+Deno.test("isTrue", async (t) => {
+  await t.step(
+    "should return true if value is true-like",
+    () => {
+      assert(isTrue(true));
+      assert(isTrue("true"));
+      assert(!isTrue("t"));
+      assert(!isTrue(false));
+      assert(!isTrue("false"));
+      assert(!isTrue(""));
+    },
+  );
 });

--- a/packages/app-opine/utils.js
+++ b/packages/app-opine/utils.js
@@ -42,5 +42,12 @@ export const isMultipartFormData = (contentType) => {
 };
 
 export const isFile = (path) => {
+  path = path || "/";
   return path.split("/").pop().indexOf(".") > -1;
 };
+
+/**
+ * Add an empty string to coerce val to
+ * a string, then compare to string 'true'
+ */
+export const isTrue = (val) => (val + "").trim() === "true";

--- a/packages/port-storage/dev_deps.js
+++ b/packages/port-storage/dev_deps.js
@@ -1,3 +1,3 @@
 // dev dependencies here
-export { assert } from "https://deno.land/std@0.127.0/testing/asserts.ts";
-export { Buffer } from "https://deno.land/std@0.127.0/io/buffer.ts";
+export { assert } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+export { Buffer } from "https://deno.land/std@0.153.0/io/buffer.ts";


### PR DESCRIPTION
This PR implements support for the presigned url flow as described in #519 

`port-storage` now accepts a `useSignedUrl` option, as a boolean.

`app-opine` route for `GET /storage/:name/*` now accepts a `useSignedUrl` query parameter, parses it to a boolean, and then will pass it to core.

So to get a presigned GET url from hyper storage, you would have a URL like:

`http://localhost:6363/storage/foo/bar.png?useSignedUrl=true`

I also updated some dev dependencies and cleaned up the test and added coverage to each. `deno fmt` also made a bunch of formatting changes.

once these are release, I can bump core and subsequently support this in core.