### PR TITLE
feat(connect): support useSignedUrl for storage.download #522

### DIFF
--- a/packages/connect/deno/services/cache.ts
+++ b/packages/connect/deno/services/cache.ts
@@ -7,43 +7,39 @@ import {
 
 const service = "cache" as const;
 
-const includeTTL = (ttl: string | undefined) =>
-  (o: HyperRequest) => ttl ? { ...o, params: { ttl } } : o;
+const includeTTL = (ttl: string | undefined) => (o: HyperRequest) =>
+  ttl ? { ...o, params: { ttl } } : o;
 
-export const add = (key: string, value: unknown, ttl?: string) =>
-  (h: HyperRequestFunction) =>
+export const add =
+  (key: string, value: unknown, ttl?: string) => (h: HyperRequestFunction) =>
     h({ service, method: Method.POST, body: { key, value, ttl } });
 
-export const get = (key: string) =>
-  (h: HyperRequestFunction) =>
-    h({ service, method: Method.GET, resource: key });
+export const get = (key: string) => (h: HyperRequestFunction) =>
+  h({ service, method: Method.GET, resource: key });
 
-export const remove = (key: string) =>
-  (h: HyperRequestFunction) =>
-    h({ service, method: Method.DELETE, resource: key });
+export const remove = (key: string) => (h: HyperRequestFunction) =>
+  h({ service, method: Method.DELETE, resource: key });
 
-export const set = (key: string, value: unknown, ttl?: string) =>
-  (h: HyperRequestFunction) =>
+export const set =
+  (key: string, value: unknown, ttl?: string) => (h: HyperRequestFunction) =>
     h(
       [{ service, method: Method.PUT, resource: key, body: value }]
         .map(includeTTL(ttl))[0],
     );
 
 // deno-lint-ignore no-inferrable-types
-export const query = (pattern: string = "*") =>
-  (h: HyperRequestFunction) =>
-    h({
-      service,
-      method: Method.POST,
-      action: Action.QUERY,
-      params: { pattern },
-    });
+export const query = (pattern: string = "*") => (h: HyperRequestFunction) =>
+  h({
+    service,
+    method: Method.POST,
+    action: Action.QUERY,
+    params: { pattern },
+  });
 
-export const create = () =>
-  (hyper: HyperRequestFunction) => hyper({ service, method: Method.PUT });
+export const create = () => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.PUT });
 
-export const destroy = (confirm = true) =>
-  (hyper: HyperRequestFunction) =>
-    confirm
-      ? hyper({ service, method: Method.DELETE })
-      : Promise.reject({ ok: false, msg: "request not confirmed!" });
+export const destroy = (confirm = true) => (hyper: HyperRequestFunction) =>
+  confirm
+    ? hyper({ service, method: Method.DELETE })
+    : Promise.reject({ ok: false, msg: "request not confirmed!" });

--- a/packages/connect/deno/services/data.ts
+++ b/packages/connect/deno/services/data.ts
@@ -10,22 +10,20 @@ import {
 
 const service = "data" as const;
 
-export const add = (body: unknown) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.POST, body });
-export const get = (id: string) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.GET, resource: id });
-export const list = (options: ListOptions = {}) =>
-  (hyper: HyperRequestFunction) =>
+export const add = (body: unknown) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.POST, body });
+export const get = (id: string) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.GET, resource: id });
+export const list =
+  (options: ListOptions = {}) => (hyper: HyperRequestFunction) =>
     hyper({ service, method: Method.GET, params: options });
-export const update = (id: string, doc: unknown) =>
-  (hyper: HyperRequestFunction) =>
+export const update =
+  (id: string, doc: unknown) => (hyper: HyperRequestFunction) =>
     hyper({ service, method: Method.PUT, resource: id, body: doc });
-export const remove = (id: string) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.DELETE, resource: id });
-export const query = (selector: unknown, options?: QueryOptions) =>
+export const remove = (id: string) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.DELETE, resource: id });
+export const query =
+  (selector: unknown, options?: QueryOptions) =>
   (hyper: HyperRequestFunction) =>
     hyper({
       service,
@@ -33,11 +31,10 @@ export const query = (selector: unknown, options?: QueryOptions) =>
       action: Action.QUERY,
       body: toDataQuery(selector, options),
     });
-export const bulk = (docs: unknown[]) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.POST, action: Action.BULK, body: docs });
-export const index = (indexName: string, fields: string[]) =>
-  (hyper: HyperRequestFunction) =>
+export const bulk = (docs: unknown[]) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.POST, action: Action.BULK, body: docs });
+export const index =
+  (indexName: string, fields: string[]) => (hyper: HyperRequestFunction) =>
     hyper({
       service,
       method: Method.POST,
@@ -49,11 +46,10 @@ export const index = (indexName: string, fields: string[]) =>
       },
     });
 
-export const create = () =>
-  (hyper: HyperRequestFunction) => hyper({ service, method: Method.PUT });
+export const create = () => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.PUT });
 
-export const destroy = (confirm = true) =>
-  (hyper: HyperRequestFunction) =>
-    confirm
-      ? hyper({ service, method: Method.DELETE })
-      : Promise.reject({ ok: false, msg: "request not confirmed!" });
+export const destroy = (confirm = true) => (hyper: HyperRequestFunction) =>
+  confirm
+    ? hyper({ service, method: Method.DELETE })
+    : Promise.reject({ ok: false, msg: "request not confirmed!" });

--- a/packages/connect/deno/services/info.ts
+++ b/packages/connect/deno/services/info.ts
@@ -2,5 +2,5 @@ import { HyperRequestFunction, Method } from "../types.ts";
 
 const service = "info" as const;
 
-export const services = () =>
-  (h: HyperRequestFunction) => h({ service, method: Method.GET });
+export const services = () => (h: HyperRequestFunction) =>
+  h({ service, method: Method.GET });

--- a/packages/connect/deno/services/queue.ts
+++ b/packages/connect/deno/services/queue.ts
@@ -2,13 +2,11 @@ import { HyperRequestFunction, Method, QueueStatus } from "../types.ts";
 
 const service = "queue" as const;
 
-export const enqueue = (body: unknown) =>
-  (h: HyperRequestFunction) => h({ service, method: Method.POST, body });
+export const enqueue = (body: unknown) => (h: HyperRequestFunction) =>
+  h({ service, method: Method.POST, body });
 
-export const errors = () =>
-  (h: HyperRequestFunction) =>
-    h({ service, method: Method.GET, params: { status: QueueStatus.ERROR } });
+export const errors = () => (h: HyperRequestFunction) =>
+  h({ service, method: Method.GET, params: { status: QueueStatus.ERROR } });
 
-export const queued = () =>
-  (h: HyperRequestFunction) =>
-    h({ service, method: Method.GET, params: { status: QueueStatus.READY } });
+export const queued = () => (h: HyperRequestFunction) =>
+  h({ service, method: Method.GET, params: { status: QueueStatus.READY } });

--- a/packages/connect/deno/services/search.ts
+++ b/packages/connect/deno/services/search.ts
@@ -11,23 +11,22 @@ const { lensPath, set } = R;
 
 const service = "search" as const;
 
-export const add = (key: string, doc: unknown) =>
-  (hyper: HyperRequestFunction) =>
+export const add =
+  (key: string, doc: unknown) => (hyper: HyperRequestFunction) =>
     hyper({ service, method: Method.POST, body: { key, doc } });
 
-export const remove = (key: string) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.DELETE, resource: key });
+export const remove = (key: string) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.DELETE, resource: key });
 
-export const get = (key: string) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.GET, resource: key });
+export const get = (key: string) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.GET, resource: key });
 
-export const update = (key: string, doc: unknown) =>
-  (hyper: HyperRequestFunction) =>
+export const update =
+  (key: string, doc: unknown) => (hyper: HyperRequestFunction) =>
     hyper({ service, method: Method.PUT, resource: key, body: doc });
 
-export const query = (query: string, options?: SearchQueryOptions) =>
+export const query =
+  (query: string, options?: SearchQueryOptions) =>
   (hyper: HyperRequestFunction) =>
     hyper(
       [{ service, method: Method.POST, action: Action.QUERY, body: { query } }]
@@ -43,16 +42,14 @@ export const query = (query: string, options?: SearchQueryOptions) =>
         )[0],
     );
 
-export const load = (docs: unknown[]) =>
-  (hyper: HyperRequestFunction) =>
-    hyper({ service, method: Method.POST, action: Action.BULK, body: docs });
+export const load = (docs: unknown[]) => (hyper: HyperRequestFunction) =>
+  hyper({ service, method: Method.POST, action: Action.BULK, body: docs });
 
-export const create = (fields: string[], storeFields?: string[]) =>
-  (hyper: HyperRequestFunction) =>
+export const create =
+  (fields: string[], storeFields?: string[]) => (hyper: HyperRequestFunction) =>
     hyper({ service, method: Method.PUT, body: { fields, storeFields } });
 
-export const destroy = (confirm = true) =>
-  (hyper: HyperRequestFunction) =>
-    confirm
-      ? hyper({ service, method: Method.DELETE })
-      : Promise.reject({ ok: false, msg: "request not confirmed!" });
+export const destroy = (confirm = true) => (hyper: HyperRequestFunction) =>
+  confirm
+    ? hyper({ service, method: Method.DELETE })
+    : Promise.reject({ ok: false, msg: "request not confirmed!" });

--- a/packages/connect/deno/services/storage.ts
+++ b/packages/connect/deno/services/storage.ts
@@ -1,4 +1,8 @@
-import { HyperRequestFunction, Method } from "../types.ts";
+import {
+  HyperRequestFunction,
+  Method,
+  StorageDownloadOptions,
+} from "../types.ts";
 
 const service = "storage" as const;
 
@@ -15,8 +19,8 @@ const createFormData = ({ name, data }: Form) => {
   return fd;
 };
 
-export const upload = (name: string, data: Uint8Array) =>
-  (h: HyperRequestFunction) =>
+export const upload =
+  (name: string, data: Uint8Array) => (h: HyperRequestFunction) =>
     Promise.resolve({ name, data })
       .then(createFormData)
       // need to override header to send content-type: multipart/form-data
@@ -34,9 +38,19 @@ export const upload = (name: string, data: Uint8Array) =>
         });
       });
 
-export const download = (name: string) =>
-  async (h: HyperRequestFunction) => {
-    const req = await h({ service, method: Method.GET, resource: name });
+export const download =
+  (name: string, options: StorageDownloadOptions = {}) =>
+  async (hyper: HyperRequestFunction) => {
+    const req = await hyper({
+      service,
+      method: Method.GET,
+      resource: name,
+      params: options,
+    });
+    /**
+     * remove the  "Content-Type": "application/json" header,
+     * but keep the Authorization header
+     */
     const headers = new Headers();
     headers.set("Authorization", req.headers.get("authorization") as string);
 
@@ -46,6 +60,5 @@ export const download = (name: string) =>
     });
   };
 
-export const remove = (name: string) =>
-  (h: HyperRequestFunction) =>
-    h({ service, method: Method.DELETE, resource: name });
+export const remove = (name: string) => (h: HyperRequestFunction) =>
+  h({ service, method: Method.DELETE, resource: name });

--- a/packages/connect/deno/tests/storage.ts
+++ b/packages/connect/deno/tests/storage.ts
@@ -16,9 +16,7 @@ test("storage.upload", async () => {
       }),
     );
   };
-  const req = await upload("avatar.png", new Uint8Array())(
-    mockRequest,
-  );
+  const req = await upload("avatar.png", new Uint8Array())(mockRequest);
   assertEquals(req.url, "http://localhost/storage/bucket");
   //const body = await req.json()
   //assertEquals(body.get('name'), 'avatar.png')
@@ -37,6 +35,30 @@ test("storage.download", async () => {
   };
   const req = await download("avatar.png")(mockRequest);
   assertEquals(req.url, "http://localhost/storage/bucket/avatar.png");
+});
+
+test("storage.download - useSignedUrl", async () => {
+  const mockRequest = (h: HyperRequest) => {
+    assertEquals(h.service, "storage");
+    assertEquals(h.method, "GET");
+    assertEquals(h.params, { useSignedUrl: true });
+
+    let url = `http://localhost/${h.service}/bucket/${h.resource}`;
+    if (h.params) {
+      url += `?${new URLSearchParams(h.params).toString()}`;
+    }
+
+    return Promise.resolve(
+      new Request(url, {
+        method: h.method,
+      }),
+    );
+  };
+  const req = await download("avatar.png", { useSignedUrl: true })(mockRequest);
+  assertEquals(
+    req.url,
+    "http://localhost/storage/bucket/avatar.png?useSignedUrl=true",
+  );
 });
 
 test("storage.remove", async () => {

--- a/packages/connect/deno/types.storage.deno.ts
+++ b/packages/connect/deno/types.storage.deno.ts
@@ -1,10 +1,10 @@
-import { Result } from "./types.ts";
+import { Result, StorageDownloadOptions } from "./types.ts";
 
 export interface HyperStorage {
-  upload: (
+  upload: (name: string, data: string | Uint8Array) => Promise<Result>;
+  download: (
     name: string,
-    data: string | Uint8Array,
-  ) => Promise<Result>;
-  download: (name: string) => Promise<ReadableStream>;
+    options?: StorageDownloadOptions,
+  ) => Promise<ReadableStream>;
   remove: (name: string) => Promise<Result>;
 }

--- a/packages/connect/deno/types.storage.node.ts
+++ b/packages/connect/deno/types.storage.node.ts
@@ -1,10 +1,10 @@
-import { Result } from "./types.ts";
+import { Result, StorageDownloadOptions } from "./types.ts";
 
 export interface HyperStorage {
-  upload: (
+  upload: (name: string, data: string | Uint8Array) => Promise<Result>;
+  download: (
     name: string,
-    data: string | Uint8Array,
-  ) => Promise<Result>;
-  download: (name: string) => Promise<NodeJS.ReadableStream>;
+    options?: StorageDownloadOptions,
+  ) => Promise<NodeJS.ReadableStream>;
   remove: (name: string) => Promise<Result>;
 }

--- a/packages/connect/deno/types.ts
+++ b/packages/connect/deno/types.ts
@@ -62,6 +62,10 @@ export interface QueryOptions {
   useIndex?: string;
 }
 
+export interface StorageDownloadOptions {
+  useSignedUrl?: boolean;
+}
+
 // TODO: exception to the rule of returning a Result shape.
 // TODO: This will change to be just a regular result in a major version
 export type HyperGetResult<Type extends Obj = Obj> = Type | NotOkResult;

--- a/packages/connect/deno/utils/hyper-request.ts
+++ b/packages/connect/deno/utils/hyper-request.ts
@@ -15,45 +15,45 @@ interface HyperRequestParams {
 }
 
 export const hyper = (conn: URL, domain: string) =>
-  async (
-    { service, method, resource, body, params, action }: HyperRequest,
-  ): Promise<HyperRequestParams> => {
-    const isCloud = /^cloud/.test(conn.protocol);
-    const protocol = isCloud ? "https:" : conn.protocol;
+async (
+  { service, method, resource, body, params, action }: HyperRequest,
+): Promise<HyperRequestParams> => {
+  const isCloud = /^cloud/.test(conn.protocol);
+  const protocol = isCloud ? "https:" : conn.protocol;
 
-    let options = {
-      headers: new Headers({
-        "Content-Type": "application/json",
-      }),
-      method: method ? method : Method.GET,
-    } as RequestOptions;
+  let options = {
+    headers: new Headers({
+      "Content-Type": "application/json",
+    }),
+    method: method ? method : Method.GET,
+  } as RequestOptions;
 
-    if (body) {
-      options = assoc("body", JSON.stringify(body), options) as RequestOptions;
-    }
+  if (body) {
+    options = assoc("body", JSON.stringify(body), options) as RequestOptions;
+  }
 
-    if (conn.username && conn.password) {
-      const token = await generateToken(conn.username, conn.password);
-      options.headers = new Headers({
-        ...Object.fromEntries(options.headers.entries()),
-        Authorization: `Bearer ${token}`,
-      });
-    }
-    const pathname = isCloud ? conn.pathname : "";
-    const appdomain = isCloud ? "/" + domain : conn.pathname;
+  if (conn.username && conn.password) {
+    const token = await generateToken(conn.username, conn.password);
+    options.headers = new Headers({
+      ...Object.fromEntries(options.headers.entries()),
+      Authorization: `Bearer ${token}`,
+    });
+  }
+  const pathname = isCloud ? conn.pathname : "";
+  const appdomain = isCloud ? "/" + domain : conn.pathname;
 
-    let url = `${protocol}//${conn.host}${pathname}/${service}${appdomain}`;
+  let url = `${protocol}//${conn.host}${pathname}/${service}${appdomain}`;
 
-    if (service === "info") {
-      url = `${protocol}//${conn.host}`;
-    }
+  if (service === "info") {
+    url = `${protocol}//${conn.host}`;
+  }
 
-    if (resource) url += `/${resource}`;
-    else if (action) url += `/${action}`;
+  if (resource) url += `/${resource}`;
+  else if (action) url += `/${action}`;
 
-    if (params) {
-      url += `?${new URLSearchParams(params).toString()}`;
-    }
+  if (params) {
+    url += `?${new URLSearchParams(params).toString()}`;
+  }
 
-    return { url, options };
-  };
+  return { url, options };
+};


### PR DESCRIPTION
This PR adds the ability to pass an `StorageDownloadOptions` object to `storage.download`. Right now the only option is `useSignedUrl`, which is then passed directly to `hyper-request` and added as query parameters on the request.

Closes #522

Also `deno fmt` formatted lots of things.