### PR TITLE
feat(connect): add signedUrl api on storage service #524

### DIFF
--- a/packages/connect/deno/mod.ts
+++ b/packages/connect/deno/mod.ts
@@ -61,8 +61,8 @@ export function connect(
           (r: Response) => r.text().then((msg: string) => ({ ok: r.ok, msg })),
         ),
       )
-      .then((r) => response.ok ? r : assoc("status", response.status, r))
-      .then((r) => response.status >= 500 ? Promise.reject(r) : r);
+      .then((r) => (response.ok ? r : assoc("status", response.status, r)))
+      .then((r) => (response.status >= 500 ? Promise.reject(r) : r));
 
   //const log = (x: any) => (console.log(x), x);
 
@@ -74,10 +74,7 @@ export function connect(
           .then(fetch)
           .then(handleResponse),
       get: (id) =>
-        Promise.resolve(h)
-          .then(data.get(id))
-          .then(fetch)
-          .then(handleResponse),
+        Promise.resolve(h).then(data.get(id)).then(fetch).then(handleResponse),
       list: (options) =>
         Promise.resolve(h)
           .then(data.list(options))
@@ -109,10 +106,7 @@ export function connect(
           .then(fetch)
           .then(handleResponse),
       create: () =>
-        Promise.resolve(h)
-          .then(data.create())
-          .then(fetch)
-          .then(handleResponse),
+        Promise.resolve(h).then(data.create()).then(fetch).then(handleResponse),
       destroy: (confirm) =>
         Promise.resolve(h)
           .then(data.destroy(confirm))
@@ -221,6 +215,10 @@ export function connect(
           // @ts-ignore
           // deno-lint-ignore no-explicit-any
           .then((res) => res.body as any),
+      signedUrl: (name, options) =>
+        Promise.resolve(h)
+          .then(storage.signedUrl(name, options))
+          .then(handleResponse),
       remove: (name) =>
         Promise.resolve(h)
           .then(storage.remove(name))
@@ -229,17 +227,20 @@ export function connect(
     },
     queue: {
       enqueue: (job) =>
-        Promise.resolve(h).then(queue.enqueue(job)).then(fetch).then(
-          handleResponse,
-        ),
+        Promise.resolve(h)
+          .then(queue.enqueue(job))
+          .then(fetch)
+          .then(handleResponse),
       errors: () =>
-        Promise.resolve(h).then(queue.errors()).then(fetch).then(
-          handleResponse,
-        ),
+        Promise.resolve(h)
+          .then(queue.errors())
+          .then(fetch)
+          .then(handleResponse),
       queued: () =>
-        Promise.resolve(h).then(queue.queued()).then(fetch).then(
-          handleResponse,
-        ),
+        Promise.resolve(h)
+          .then(queue.queued())
+          .then(fetch)
+          .then(handleResponse),
     },
     info: {
       services: () =>

--- a/packages/connect/deno/services/storage.ts
+++ b/packages/connect/deno/services/storage.ts
@@ -1,7 +1,7 @@
 import {
   HyperRequestFunction,
   Method,
-  StorageDownloadOptions,
+  StorageSignedUrlOptions,
 } from "../types.ts";
 
 const service = "storage" as const;
@@ -39,13 +39,11 @@ export const upload =
       });
 
 export const download =
-  (name: string, options: StorageDownloadOptions = {}) =>
-  async (hyper: HyperRequestFunction) => {
+  (name: string) => async (hyper: HyperRequestFunction) => {
     const req = await hyper({
       service,
       method: Method.GET,
       resource: name,
-      params: options,
     });
     /**
      * remove the  "Content-Type": "application/json" header,
@@ -59,6 +57,18 @@ export const download =
       headers,
     });
   };
+
+export const signedUrl =
+  (name: string, options: StorageSignedUrlOptions) =>
+  (hyper: HyperRequestFunction) =>
+    hyper({
+      service,
+      resource: name,
+      method: options.type === "download" ? Method.GET : Method.POST,
+      ...(options.type === "download"
+        ? { params: { useSignedUrl: true } }
+        : {}),
+    });
 
 export const remove = (name: string) => (h: HyperRequestFunction) =>
   h({ service, method: Method.DELETE, resource: name });

--- a/packages/connect/deno/types.storage.deno.ts
+++ b/packages/connect/deno/types.storage.deno.ts
@@ -1,10 +1,16 @@
-import { Result, StorageDownloadOptions } from "./types.ts";
+import {
+  NotOkResult,
+  OkUrlResult,
+  Result,
+  StorageSignedUrlOptions,
+} from "./types.ts";
 
 export interface HyperStorage {
   upload: (name: string, data: string | Uint8Array) => Promise<Result>;
-  download: (
+  download: (name: string) => Promise<ReadableStream>;
+  signedUrl: (
     name: string,
-    options?: StorageDownloadOptions,
-  ) => Promise<ReadableStream>;
+    options: StorageSignedUrlOptions,
+  ) => Promise<OkUrlResult | NotOkResult>;
   remove: (name: string) => Promise<Result>;
 }

--- a/packages/connect/deno/types.storage.node.ts
+++ b/packages/connect/deno/types.storage.node.ts
@@ -1,10 +1,16 @@
-import { Result, StorageDownloadOptions } from "./types.ts";
+import {
+  NotOkResult,
+  OkUrlResult,
+  Result,
+  StorageSignedUrlOptions,
+} from "./types.ts";
 
 export interface HyperStorage {
   upload: (name: string, data: string | Uint8Array) => Promise<Result>;
-  download: (
+  download: (name: string) => Promise<NodeJS.ReadableStream>;
+  signedUrl: (
     name: string,
-    options?: StorageDownloadOptions,
-  ) => Promise<NodeJS.ReadableStream>;
+    options: StorageSignedUrlOptions,
+  ) => Promise<OkUrlResult | NotOkResult>;
   remove: (name: string) => Promise<Result>;
 }

--- a/packages/connect/deno/types.ts
+++ b/packages/connect/deno/types.ts
@@ -49,6 +49,11 @@ export interface NotOkResult {
 export type Result = OkResult | NotOkResult;
 export type OkIdResult = OkResult & { id: string };
 export type IdResult = OkIdResult | NotOkResult;
+export type OkUrlResult = OkResult & { url: string };
+
+export interface StorageSignedUrlOptions {
+  type: "upload" | "download";
+}
 
 export interface SearchQueryOptions {
   fields: string[];
@@ -60,10 +65,6 @@ export interface QueryOptions {
   sort?: { [k: string]: SortOptions }[];
   limit?: number;
   useIndex?: string;
-}
-
-export interface StorageDownloadOptions {
-  useSignedUrl?: boolean;
 }
 
 // TODO: exception to the rule of returning a Result shape.


### PR DESCRIPTION
BREAKING CHANGE: removed `StorageDownloadOptions` from `storage.download`.
Consumers should instead use `storage.signedUrl(name, { type: 'download' })