### PR TITLE
feat(app-express): add search routes and start of test #562

### DIFF
--- a/packages/app-express/api/mod.ts
+++ b/packages/app-express/api/mod.ts
@@ -4,6 +4,7 @@ import { HyperServices, Server } from '../types.ts'
 import { data } from './data.ts'
 import { cache } from './cache.ts'
 import { crawler } from './crawler.ts'
+import { search } from './search.ts'
 
 const { when, compose } = R
 
@@ -12,6 +13,7 @@ export const mountServicesWith = (services: HyperServices) => (app: Server) => {
 
   return compose(
     // Add more as I implement them
+    when(() => hasService('search'), search(services)),
     when(() => hasService('crawler'), crawler(services)),
     when(() => hasService('cache'), cache(services)),
     when(() => hasService('data'), data(services)),

--- a/packages/app-express/api/search.test.ts
+++ b/packages/app-express/api/search.test.ts
@@ -1,0 +1,75 @@
+// deno-lint-ignore-file ban-ts-comment no-explicit-any
+import { crocks, express } from '../deps.ts'
+import { assertEquals, assertObjectMatch } from '../dev_deps.ts'
+import { createHarness } from '../test-utils.ts'
+
+import { search } from './search.ts'
+
+const services: any = {
+  search: {
+    createIndex: (index: any, mapping: any) =>
+      crocks.Async.Resolved({
+        ok: true,
+        index,
+        mapping,
+      }),
+  },
+}
+
+// @ts-ignore
+const app = search(services)(express())
+
+Deno.test('search', async (t) => {
+  const harness = createHarness(app)
+
+  await t.step('PUT /search/:index', async (t) => {
+    await t.step('should set the content-type header', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/search/movies', {
+            method: 'PUT',
+            body: JSON.stringify({
+              fields: ['foo'],
+              storeFields: ['foo', 'bar'],
+            }),
+          }).then((res) => {
+            assertEquals(
+              res.headers.get('content-type'),
+              'application/json; charset=utf-8',
+            )
+            return res.body?.cancel()
+          })
+        )
+        .finally(async () => await harness.stop())
+    })
+
+    await t.step(
+      'should pass index route params and body to core',
+      async () => {
+        await harness
+          .start()
+          .then(() =>
+            harness('/search/movies', {
+              method: 'PUT',
+              body: JSON.stringify({
+                fields: ['foo'],
+                storeFields: ['foo', 'bar'],
+              }),
+            })
+              .then((res) => res.json())
+              .then((body) => {
+                assertEquals(body.index, 'movies')
+                assertObjectMatch(body.mapping, {
+                  fields: ['foo'],
+                  storeFields: ['foo', 'bar'],
+                })
+              })
+          )
+          .finally(async () => await harness.stop())
+      },
+    )
+  })
+
+  // TODO: add more test coverage here
+})

--- a/packages/app-express/api/search.ts
+++ b/packages/app-express/api/search.ts
@@ -1,0 +1,89 @@
+import { fork } from '../utils.ts'
+import type { HyperServices, Server } from '../types.ts'
+import { bindCore } from '../middleware/bindCore.ts'
+import { json } from '../middleware/json.ts'
+
+type IndexParams = { index: string }
+type KeyParams = { key: string }
+
+type IndexBody = {
+  fields: string[]
+  storeFields?: string[]
+}
+
+type QueryBody = {
+  query: string
+  fields?: string[]
+  filter?: Record<string, unknown>
+}
+
+type SearchDoc = ({ id: string } | { _id: string }) & Record<string, unknown>
+
+export const search = (services: HyperServices) => (app: Server) => {
+  app.get(
+    '/search',
+    (_req, res) => res.send({ name: 'hyper63 Search', version: '1.0', status: 'unstable' }),
+  )
+
+  // deno-lint-ignore no-explicit-any
+  app.put<IndexParams, any, IndexBody>(
+    '/search/:index',
+    json(),
+    bindCore(services),
+    ({ params, search, body }, res) => fork(res, 201, search.createIndex(params.index, body)),
+  )
+
+  app.delete<IndexParams>(
+    '/search/:index',
+    bindCore(services),
+    ({ params, search }, res) => fork(res, 200, search.deleteIndex(params.index)),
+  )
+
+  // deno-lint-ignore no-explicit-any
+  app.post<IndexParams, any, { key: string; doc: Record<string, unknown> }>(
+    '/search/:index',
+    json(),
+    bindCore(services),
+    ({ params, body, search }, res) =>
+      fork(res, 201, search.indexDoc(params.index, body.key, body.doc)),
+  )
+
+  app.get<IndexParams & KeyParams>(
+    '/search/:index/:key',
+    bindCore(services),
+    ({ params, search }, res) => fork(res, 200, search.getDoc(params.index, params.key)),
+  )
+
+  // deno-lint-ignore no-explicit-any
+  app.put<IndexParams & KeyParams, any, Record<string, unknown>>(
+    '/search/:index/:key',
+    json(),
+    bindCore(services),
+    ({ search, params, body }, res) =>
+      fork(res, 200, search.updateDoc(params.index, params.key, body)),
+  )
+
+  app.delete<IndexParams & KeyParams>(
+    '/search/:index/:key',
+    bindCore(services),
+    ({ search, params }, res) => fork(res, 200, search.removeDoc(params.index, params.key)),
+  )
+
+  // deno-lint-ignore no-explicit-any
+  app.post<IndexParams, any, QueryBody>(
+    '/search/:index/_query',
+    json(),
+    bindCore(services),
+    ({ search, params, body }, res) => fork(res, 200, search.query(params.index, body)),
+  )
+
+  // deno-lint-ignore no-explicit-any
+  app.post<IndexParams, any, SearchDoc[]>(
+    '/search/:index/_bulk',
+    json(),
+    bindCore(services),
+    ({ search, params, body }, res) => fork(res, 201, search.bulk(params.index, body)),
+  )
+
+  return app
+}

--- a/packages/app-express/middleware/json.test.ts
+++ b/packages/app-express/middleware/json.test.ts
@@ -1,0 +1,91 @@
+import { express } from '../deps.ts'
+import { assertObjectMatch } from '../dev_deps.ts'
+import { createHarness } from '../test-utils.ts'
+
+import { json } from './json.ts'
+
+const app = express()
+app.post('/foo/bar', json(), (req, res) => {
+  res.json(req.body)
+})
+
+Deno.test('json', async (t) => {
+  const harness = createHarness(app)
+
+  await t.step('should parse if application/json content-type', async () => {
+    await harness
+      .start()
+      .then(() =>
+        harness('/foo/bar', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: '1', type: 'movie' }),
+        })
+          .then((res) => res.json())
+          .then((body) => {
+            assertObjectMatch(body, { id: '1', type: 'movie' })
+          })
+      )
+      .finally(async () => await harness.stop())
+  })
+
+  await t.step(
+    'should default parsing if no content-type is specified',
+    async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/foo/bar', {
+            method: 'POST',
+            body: JSON.stringify({ id: '1', type: 'movie' }),
+          })
+            .then((res) => res.json())
+            .then((body) => {
+              assertObjectMatch(body, { id: '1', type: 'movie' })
+            })
+        )
+        .finally(async () => await harness.stop())
+    },
+  )
+
+  await t.step('should respect the provided type', async (t) => {
+    const app = express()
+    app.post('/foo/bar', json({ type: 'foo/bar' }), (req, res) => {
+      res.json(req.body)
+    })
+    const harness = createHarness(app)
+
+    await t.step('should parse as json', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/foo/bar', {
+            method: 'POST',
+            headers: { 'content-type': 'foo/bar' },
+            body: JSON.stringify({ id: '1', type: 'movie' }),
+          })
+            .then((res) => res.json())
+            .then((body) => {
+              assertObjectMatch(body, { id: '1', type: 'movie' })
+            })
+        )
+        .finally(async () => await harness.stop())
+    })
+
+    await t.step('should parse as json', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/foo/bar', {
+            method: 'POST',
+            body: JSON.stringify({ id: '1', type: 'movie' }),
+          })
+            .then((res) => res.json())
+            .then((body) => {
+              assertObjectMatch({}, body)
+            })
+        )
+        .finally(async () => await harness.stop())
+    })
+  })
+})

--- a/packages/app-express/middleware/json.ts
+++ b/packages/app-express/middleware/json.ts
@@ -1,3 +1,16 @@
 import { express } from '../deps.ts'
 
-export const json = express.json
+/**
+ * Parses a requst body as JSON. Identical
+ * to the standard json() middleware with the distinction
+ * of setting a default catch-all content type option.
+ *
+ * Because we set type to a wildcard,
+ * This middleware will always parse the request body as JSON, regardless of
+ * content-type header.
+ *
+ * This is to take into account, badly behaved clients
+ * that don't provide the header explictly
+ */
+export const json = (options: Parameters<typeof express.json>[0] = {}) =>
+  express.json({ type: '*/*', ...options })

--- a/packages/app-express/middleware/legacyGet.test.ts
+++ b/packages/app-express/middleware/legacyGet.test.ts
@@ -13,30 +13,48 @@ Deno.test('legacyGet', async (t) => {
   const harness = createHarness(app)
 
   await t.step('should set isLegacyGetEnabled to true', async () => {
-    await harness.start()
-    const on = await harness('/foo/bar', {
-      headers: { 'x-hyper-legacy-get': 'true' },
-    }).then((res) => res.json())
-    assert(on.isLegacyGetEnabled)
-    await harness.stop()
+    await harness
+      .start()
+      .then(() =>
+        harness('/foo/bar', {
+          headers: { 'x-hyper-legacy-get': 'true' },
+        })
+          .then((res) => res.json())
+          .then((body) => {
+            assert(body.isLegacyGetEnabled)
+          })
+      )
+      .finally(async () => await harness.stop())
   })
 
   await t.step('should set isLegacyGetEnabled to false', async () => {
-    await harness.start()
-    const off = await harness('/foo/bar', {
-      headers: { 'x-hyper-legacy-get': 'false' },
-    }).then((res) => res.json())
-    assert(!off.isLegacyGetEnabled)
-    await harness.stop()
+    await harness
+      .start()
+      .then(() =>
+        harness('/foo/bar', {
+          headers: { 'x-hyper-legacy-get': 'false' },
+        })
+          .then((res) => res.json())
+          .then((body) => {
+            assert(!body.isLegacyGetEnabled)
+          })
+      )
+      .finally(async () => await harness.stop())
   })
 
   await t.step(
     'should not set isLegacyGetEnabled if header is not provided',
     async () => {
-      await harness.start()
-      const on = await harness('/foo/bar').then((res) => res.json())
-      assert(on.isLegacyGetEnabled === undefined)
-      await harness.stop()
+      await harness
+        .start()
+        .then(() =>
+          harness('/foo/bar')
+            .then((res) => res.json())
+            .then((body) => {
+              assert(body.isLegacyGetEnabled === undefined)
+            })
+        )
+        .finally(async () => await harness.stop())
     },
   )
 })


### PR DESCRIPTION
Closes #562 

Also made the `json` middleware more flexible, by it defaulting to parsing the request body as JSON, even if `content-type` is not provided on the request.