### PR TITLE
feat(app-express): add start of storage routes and start of tests #569

### DIFF
--- a/packages/app-express/api/mod.ts
+++ b/packages/app-express/api/mod.ts
@@ -4,6 +4,7 @@ import { HyperServices, Server } from '../types.ts'
 import { data } from './data.ts'
 import { cache } from './cache.ts'
 import { search } from './search.ts'
+import { storage } from './storage.ts'
 import { queue } from './queue.ts'
 import { crawler } from './crawler.ts'
 
@@ -13,9 +14,9 @@ export const mountServicesWith = (services: HyperServices) => (app: Server) => {
   const hasService = (service: keyof HyperServices) => !!services[service]
 
   return compose(
-    // Add more as I implement them
     when(() => hasService('crawler'), crawler(services)),
     when(() => hasService('queue'), queue(services)),
+    when(() => hasService('storage'), storage(services)),
     when(() => hasService('search'), search(services)),
     when(() => hasService('cache'), cache(services)),
     when(() => hasService('data'), data(services)),

--- a/packages/app-express/api/storage.test.ts
+++ b/packages/app-express/api/storage.test.ts
@@ -1,0 +1,142 @@
+// deno-lint-ignore-file ban-ts-comment no-explicit-any
+import { crocks, express } from '../deps.ts'
+import { assertEquals } from '../dev_deps.ts'
+import { createHarness } from '../test-utils.ts'
+
+import { storage } from './storage.ts'
+
+const services: any = {
+  storage: {
+    makeBucket: (name: any) =>
+      crocks.Async.Resolved({
+        ok: true,
+        name,
+      }),
+    removeBucket: (name: any) =>
+      crocks.Async.Resolved({
+        ok: true,
+        name,
+      }),
+    removeObject: (name: any, object: any) =>
+      crocks.Async.Resolved({
+        ok: true,
+        name,
+        object,
+      }),
+  },
+}
+
+// @ts-ignore
+const app = storage(services)(express())
+
+Deno.test('storage', async (t) => {
+  const harness = createHarness(app)
+
+  await t.step('PUT /storage/:name', async (t) => {
+    await t.step('should set the content-type header', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/storage/movies', {
+            method: 'PUT',
+          }).then((res) => {
+            assertEquals(
+              res.headers.get('content-type'),
+              'application/json; charset=utf-8',
+            )
+            return res.body?.cancel()
+          })
+        )
+        .finally(async () => await harness.stop())
+    })
+
+    await t.step('should pass name route param to core', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/storage/movies', {
+            method: 'PUT',
+          })
+            .then((res) => res.json())
+            .then((body) => {
+              assertEquals(body.name, 'movies')
+            })
+        )
+        .finally(async () => await harness.stop())
+    })
+  })
+
+  await t.step('DELETE /storage/:name', async (t) => {
+    await t.step('should set the content-type header', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/storage/movies', {
+            method: 'DELETE',
+          }).then((res) => {
+            assertEquals(
+              res.headers.get('content-type'),
+              'application/json; charset=utf-8',
+            )
+            return res.body?.cancel()
+          })
+        )
+        .finally(async () => await harness.stop())
+    })
+
+    await t.step('should pass name route param to core', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/storage/movies', {
+            method: 'DELETE',
+          })
+            .then((res) => res.json())
+            .then((body) => {
+              assertEquals(body.name, 'movies')
+            })
+        )
+        .finally(async () => await harness.stop())
+    })
+  })
+
+  await t.step('DELETE /storage/:name/*', async (t) => {
+    await t.step('should set the content-type header', async () => {
+      await harness
+        .start()
+        .then(() =>
+          harness('/storage/movies/foo/bar.png', {
+            method: 'DELETE',
+          }).then((res) => {
+            assertEquals(
+              res.headers.get('content-type'),
+              'application/json; charset=utf-8',
+            )
+            return res.body?.cancel()
+          })
+        )
+        .finally(async () => await harness.stop())
+    })
+
+    await t.step(
+      'should pass name and object route params to core',
+      async () => {
+        await harness
+          .start()
+          .then(() =>
+            harness('/storage/movies/foo/bar.png', {
+              method: 'DELETE',
+            })
+              .then((res) => res.json())
+              .then((body) => {
+                assertEquals(body.name, 'movies')
+                assertEquals(body.object, 'foo/bar.png')
+              })
+          )
+          .finally(async () => await harness.stop())
+      },
+    )
+  })
+
+  // TODO: add more test coverage here
+})

--- a/packages/app-express/api/storage.ts
+++ b/packages/app-express/api/storage.ts
@@ -1,0 +1,32 @@
+import { fork } from '../utils.ts'
+import type { HyperServices, Server } from '../types.ts'
+import { bindCore } from '../middleware/bindCore.ts'
+
+type NameParams = { name: string }
+
+export const storage = (services: HyperServices) => (app: Server) => {
+  app.get(
+    '/storage',
+    (_req, res) => res.send({ name: 'hyper63 Storage', version: '1.0', status: 'unstable' }),
+  )
+
+  app.put<NameParams>(
+    '/storage/:name',
+    bindCore(services),
+    ({ params, storage }, res) => fork(res, 201, storage.makeBucket(params.name)),
+  )
+
+  app.delete<NameParams>(
+    '/storage/:name',
+    bindCore(services),
+    ({ params, storage }, res) => fork(res, 201, storage.removeBucket(params.name)),
+  )
+
+  app.delete(
+    '/storage/:name/*',
+    bindCore(services),
+    ({ params, storage }, res) => fork(res, 201, storage.removeObject(params.name, params[0])),
+  )
+
+  return app
+}

--- a/packages/app-express/deno.lock
+++ b/packages/app-express/deno.lock
@@ -330,6 +330,10 @@
     "https://deno.land/std@0.178.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
     "https://deno.land/std@0.178.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
     "https://deno.land/std@0.178.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab",
+    "https://deno.land/std@0.180.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
+    "https://deno.land/std@0.180.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.180.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.180.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab",
     "https://deno.land/x/port@1.0.0/mod.ts": "2dc04ce1ccf133ae09205e30b550044c4c6f64a1a7d00ea91c66dbb9f6cc00f5",
     "https://deno.land/x/port@1.0.0/types.ts": "42d6ae4147d5d67408d60209da070ddfa79ec8389c6cab1b8002df0cf6c03af6",
     "https://nh4m2oo3u2uzqx2uyiruod74pqtbtiphcid2l3i4mzutjvinek7q.arweave.net/afjNOdumqZhfVMIjRw_8fCYZoecSB6XtHGZpNNUNIr8/hyper-err.js": "434ce4bd1cc58e220aad95148bfb04ad7c43738cb5f771a02a45ea8608ac71cc"
@@ -345,19 +349,19 @@
         "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
         "dependencies": {
           "@types/connect": "@types/connect@3.4.35",
-          "@types/node": "@types/node@18.14.6"
+          "@types/node": "@types/node@18.15.5"
         }
       },
       "@types/connect@3.4.35": {
         "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
         "dependencies": {
-          "@types/node": "@types/node@18.14.6"
+          "@types/node": "@types/node@18.15.5"
         }
       },
       "@types/express-serve-static-core@4.17.33": {
         "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
         "dependencies": {
-          "@types/node": "@types/node@18.14.6",
+          "@types/node": "@types/node@18.15.5",
           "@types/qs": "@types/qs@6.9.7",
           "@types/range-parser": "@types/range-parser@1.2.4"
         }
@@ -375,8 +379,8 @@
         "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
         "dependencies": {}
       },
-      "@types/node@18.14.6": {
-        "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
+      "@types/node@18.15.5": {
+        "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
         "dependencies": {}
       },
       "@types/qs@6.9.7": {
@@ -391,7 +395,7 @@
         "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
         "dependencies": {
           "@types/mime": "@types/mime@3.0.1",
-          "@types/node": "@types/node@18.14.6"
+          "@types/node": "@types/node@18.15.5"
         }
       },
       "accepts@1.3.8": {

--- a/packages/app-express/dev_deps.ts
+++ b/packages/app-express/dev_deps.ts
@@ -2,5 +2,5 @@ export {
   assert,
   assertEquals,
   assertObjectMatch,
-} from 'https://deno.land/std@0.178.0/testing/asserts.ts'
+} from 'https://deno.land/std@0.180.0/testing/asserts.ts'
 export { getAvailablePortSync } from 'https://deno.land/x/port@1.0.0/mod.ts'

--- a/packages/app-express/utils.ts
+++ b/packages/app-express/utils.ts
@@ -55,8 +55,7 @@ export const fork = <R extends HyperResponse, L = any>(
     },
   )
 
-export const isMultipartFormData = (contentType: string) => {
-  contentType = contentType || ''
+export const isMultipartFormData = (contentType = '') => {
   return contentType.startsWith('multipart/form-data')
 }
 


### PR DESCRIPTION
This PR adds the start of the `storage` service routes and their full corresponding tests.

Next is to do `putObject` and `getObject` as separate PRs since they are their own beasts.