### PR TITLE
feat(app-express): implement putObject endpoints and support streaming body #569 #556 #571

### DIFF
--- a/packages/app-express/api/storage.ts
+++ b/packages/app-express/api/storage.ts
@@ -1,8 +1,93 @@
-import { fork } from '../utils.ts'
-import type { HyperServices, Server } from '../types.ts'
+import { crocks, readerFromIterable } from '../deps.ts'
+import { fork, isFile } from '../utils.ts'
+import type { HttpResponse, HyperServices, Server, UploadedFile } from '../types.ts'
 import { bindCore } from '../middleware/bindCore.ts'
+import { formData, objectBodyParser } from '../middleware/object.ts'
 
-type NameParams = { name: string }
+const { Async } = crocks
+
+type NameParams = { name: string; 0?: string }
+
+async function formDataObject({
+  params,
+  file,
+  path,
+  storage,
+  res,
+}: {
+  params: NameParams
+  file?: UploadedFile
+  path: string | undefined
+  storage: HyperServices['storage']
+  res: HttpResponse
+}) {
+  if (!file) {
+    return res.status(422).json({
+      ok: false,
+      status: 422,
+      msg: 'body must be FormData that contains a file field and optional path field',
+    })
+  }
+
+  const bucket = params.name
+  // object is placed at root of bucket, by default
+  let object = file.originalname
+  const useSignedUrl = false
+  /**
+   * object can be placed in "subdirectories" within the bucket
+   *
+   * If a path is provided in the formData,
+   * combine with object to create the full object path
+   * to be passed to core
+   *
+   * From multer:
+   *   req.body will hold the text fields, if there were any
+   */
+  if (path) {
+    /**
+     * The filename, from FormData, takes precedent over any filename in path,
+     *
+     * Examples:
+     *
+     * POST /bucket/foo/bar.jpg form-data: (file: actual.jpg) will
+     * ignore `bar.jpg` and use `actual.jpg` for the filename
+     * effectively acting as POST /bucket/foo form-data: (file: actual.jpg)
+     *
+     * POST /bucket form-data: (file: actual.jpg, path: foo/bar.jpg) will
+     * ignore `bar.jpg` and use `actual.jpg` for the filename
+     * effectively acting as POST /bucket/foo form-data: (file: actual.jpg)
+     */
+    if (isFile(path)) path = path.split('/').slice(0, -1).join('/')
+    if (path.endsWith('/')) path = path.slice(0, -1)
+    object = `${path}/${object}`
+  }
+
+  const reader: Deno.Reader & Deno.Closer = await Deno.open(file.path, {
+    read: true,
+  })
+  /**
+   * Ensure reader is closed, if defined, to prevent leaks
+   * in the case of a tempfile being created
+   */
+  const cleanup = (
+    _p: PromiseConstructor['resolve'] | PromiseConstructor['reject'],
+  ) =>
+    Async.fromPromise(async (res: unknown) => {
+      if (reader && typeof reader.close === 'function') await reader.close()
+      return _p(res)
+    })
+
+  return fork(
+    res,
+    201,
+    storage
+      .putObject(bucket, object, reader, useSignedUrl)
+      .bichain(
+        cleanup(Promise.reject.bind(Promise)),
+        cleanup(Promise.resolve.bind(Promise)),
+      ),
+  )
+}
 
 export const storage = (services: HyperServices) => (app: Server) => {
   app.get(
@@ -20,6 +105,92 @@ export const storage = (services: HyperServices) => (app: Server) => {
     '/storage/:name',
     bindCore(services),
     ({ params, storage }, res) => fork(res, 201, storage.removeBucket(params.name)),
+  )
+
+  /**
+   * Allows for specifying a path in the url that the object should be placed at
+   */
+  app.post<NameParams>(
+    '/storage/:name/*',
+    bindCore(services),
+    objectBodyParser,
+    (req, res) => {
+      const {
+        params,
+        file,
+        body,
+        storage,
+        isBinary,
+        isMultipartFormData,
+        useSignedUrl,
+      } = req
+      const bucket = params.name
+
+      if (isMultipartFormData) {
+        const path = body?.path || params[0] || undefined
+        return formDataObject({ params, file, path, storage, res })
+      }
+
+      // map all falsey to undefined, then let Storage port parse and catch
+      const object = params[0] || undefined
+
+      if (useSignedUrl) {
+        // The reader is always undefined when using a signed url flow
+        const reader = undefined
+        return fork(
+          res,
+          201,
+          storage.putObject(bucket, object, reader, useSignedUrl),
+        )
+      }
+
+      if (isBinary) {
+        /**
+         * Convert the Express request into a Deno Reader.
+         *
+         * This works because Express' Request is an embellished
+         * http.IncomingMessage which is an embellished stream.Readble
+         * which is in turn an AsyncIterator
+         *
+         * See https://nodejs.org/api/http.html#class-httpincomingmessage
+         * which extends https://nodejs.org/api/stream.html#class-streamreadable
+         * which implements https://nodejs.org/api/stream.html#readablesymbolasynciterator
+         *
+         * This allows us to stream the request body into the adapter
+         * without having to first buffer the entire body into memory
+         * or onto disk. Depending on the adapter implementation, this means
+         * a file could be completely streamed through hyper without having to buffer
+         * the whole file on process. See
+         */
+        const reader = readerFromIterable(
+          req as unknown as AsyncIterable<Uint8Array>,
+        )
+        return fork(
+          res,
+          201,
+          storage.putObject(bucket, object, reader, useSignedUrl),
+        )
+      }
+
+      return res
+        .status(422)
+        .json({ ok: false, status: 422, msg: 'Unprocessable Entity' })
+    },
+  )
+
+  /**
+   * This path is required to be multipart/form-data
+   * because otherwise the route has no way of determining the name of the file
+   * from the request
+   *
+   * So if it is NOT multipart/form-data, then we will return a 422
+   */
+  app.post<NameParams>(
+    '/storage/:name',
+    bindCore(services),
+    formData,
+    ({ params, file, body, storage }, res) =>
+      formDataObject({ params, file, path: body?.path, storage, res }),
   )
 
   app.delete(

--- a/packages/app-express/deno.lock
+++ b/packages/app-express/deno.lock
@@ -326,42 +326,48 @@
     "https://cdn.skypack.dev/helmet@6.0.1?dts": "61adf27d5338ce683c0226d23bdd646fa3cc46ba7d4ddc5a4db34f3512ec27a8",
     "https://cdn.skypack.dev/ramda@0.28.0": "ac1e3c64a2a3491971bee55f88faeb0923023e903d3ad125f1bd8044b4cad03e",
     "https://cdn.skypack.dev/ramda@0.28.0?dts": "ac1e3c64a2a3491971bee55f88faeb0923023e903d3ad125f1bd8044b4cad03e",
-    "https://deno.land/std@0.178.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
-    "https://deno.land/std@0.178.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.178.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.178.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab",
-    "https://deno.land/std@0.180.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
-    "https://deno.land/std@0.180.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.180.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.180.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab",
+    "https://deno.land/std@0.181.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
+    "https://deno.land/std@0.181.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
+    "https://deno.land/std@0.181.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.181.0/io/buffer.ts": "17f4410eaaa60a8a85733e8891349a619eadfbbe42e2f319283ce2b8f29723ab",
+    "https://deno.land/std@0.181.0/streams/reader_from_iterable.ts": "55f68110dce3f8f2c87b834d95f153bc904257fc65175f9f2abe78455cb8047c",
+    "https://deno.land/std@0.181.0/streams/write_all.ts": "aec90152978581ea62d56bb53a5cbf487e6a89c902f87c5969681ffbdf32b998",
+    "https://deno.land/std@0.181.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.181.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.181.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
+    "https://deno.land/std@0.181.0/types.d.ts": "dbaeb2c4d7c526db9828fc8df89d8aecf53b9ced72e0c4568f97ddd8cda616a4",
     "https://deno.land/x/port@1.0.0/mod.ts": "2dc04ce1ccf133ae09205e30b550044c4c6f64a1a7d00ea91c66dbb9f6cc00f5",
     "https://deno.land/x/port@1.0.0/types.ts": "42d6ae4147d5d67408d60209da070ddfa79ec8389c6cab1b8002df0cf6c03af6",
     "https://nh4m2oo3u2uzqx2uyiruod74pqtbtiphcid2l3i4mzutjvinek7q.arweave.net/afjNOdumqZhfVMIjRw_8fCYZoecSB6XtHGZpNNUNIr8/hyper-err.js": "434ce4bd1cc58e220aad95148bfb04ad7c43738cb5f771a02a45ea8608ac71cc"
   },
   "npm": {
     "specifiers": {
+      "@types/body-parser@^1.19.2": "@types/body-parser@1.19.2",
       "@types/express@^4.17": "@types/express@4.17.17",
+      "@types/multer@^1.4.7": "@types/multer@1.4.7",
+      "body-parser@1.20.2": "body-parser@1.20.2",
       "cors@2.8.5": "cors@2.8.5",
-      "express@4.18.2": "express@4.18.2"
+      "express@4.18.2": "express@4.18.2",
+      "multer@1.4.4": "multer@1.4.4"
     },
     "packages": {
       "@types/body-parser@1.19.2": {
         "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
         "dependencies": {
           "@types/connect": "@types/connect@3.4.35",
-          "@types/node": "@types/node@18.15.5"
+          "@types/node": "@types/node@18.15.7"
         }
       },
       "@types/connect@3.4.35": {
         "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
         "dependencies": {
-          "@types/node": "@types/node@18.15.5"
+          "@types/node": "@types/node@18.15.7"
         }
       },
       "@types/express-serve-static-core@4.17.33": {
         "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
         "dependencies": {
-          "@types/node": "@types/node@18.15.5",
+          "@types/node": "@types/node@18.15.7",
           "@types/qs": "@types/qs@6.9.7",
           "@types/range-parser": "@types/range-parser@1.2.4"
         }
@@ -379,8 +385,14 @@
         "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
         "dependencies": {}
       },
-      "@types/node@18.15.5": {
-        "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
+      "@types/multer@1.4.7": {
+        "integrity": "sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==",
+        "dependencies": {
+          "@types/express": "@types/express@4.17.17"
+        }
+      },
+      "@types/node@18.15.7": {
+        "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA==",
         "dependencies": {}
       },
       "@types/qs@6.9.7": {
@@ -395,7 +407,7 @@
         "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
         "dependencies": {
           "@types/mime": "@types/mime@3.0.1",
-          "@types/node": "@types/node@18.15.5"
+          "@types/node": "@types/node@18.15.7"
         }
       },
       "accepts@1.3.8": {
@@ -404,6 +416,10 @@
           "mime-types": "mime-types@2.1.35",
           "negotiator": "negotiator@0.6.3"
         }
+      },
+      "append-field@1.0.0": {
+        "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+        "dependencies": {}
       },
       "array-flatten@1.1.1": {
         "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
@@ -426,6 +442,34 @@
           "unpipe": "unpipe@1.0.0"
         }
       },
+      "body-parser@1.20.2": {
+        "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+        "dependencies": {
+          "bytes": "bytes@3.1.2",
+          "content-type": "content-type@1.0.5",
+          "debug": "debug@2.6.9",
+          "depd": "depd@2.0.0",
+          "destroy": "destroy@1.2.0",
+          "http-errors": "http-errors@2.0.0",
+          "iconv-lite": "iconv-lite@0.4.24",
+          "on-finished": "on-finished@2.4.1",
+          "qs": "qs@6.11.0",
+          "raw-body": "raw-body@2.5.2",
+          "type-is": "type-is@1.6.18",
+          "unpipe": "unpipe@1.0.0"
+        }
+      },
+      "buffer-from@1.1.2": {
+        "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+        "dependencies": {}
+      },
+      "busboy@0.2.14": {
+        "integrity": "sha512-InWFDomvlkEj+xWLBfU3AvnbVYqeTWmQopiW0tWWEy5yehYm2YkGEc59sUmw/4ty5Zj/b0WHGs1LgecuBSBGrg==",
+        "dependencies": {
+          "dicer": "dicer@0.2.5",
+          "readable-stream": "readable-stream@1.1.14"
+        }
+      },
       "bytes@3.1.2": {
         "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
         "dependencies": {}
@@ -435,6 +479,15 @@
         "dependencies": {
           "function-bind": "function-bind@1.1.1",
           "get-intrinsic": "get-intrinsic@1.2.0"
+        }
+      },
+      "concat-stream@1.6.2": {
+        "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+        "dependencies": {
+          "buffer-from": "buffer-from@1.1.2",
+          "inherits": "inherits@2.0.4",
+          "readable-stream": "readable-stream@2.3.8",
+          "typedarray": "typedarray@0.0.6"
         }
       },
       "content-disposition@0.5.4": {
@@ -453,6 +506,10 @@
       },
       "cookie@0.5.0": {
         "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+        "dependencies": {}
+      },
+      "core-util-is@1.0.3": {
+        "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
         "dependencies": {}
       },
       "cors@2.8.5": {
@@ -475,6 +532,13 @@
       "destroy@1.2.0": {
         "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
         "dependencies": {}
+      },
+      "dicer@0.2.5": {
+        "integrity": "sha512-FDvbtnq7dzlPz0wyYlOExifDEZcu8h+rErEXgfxqmLfRfC/kJidEFh4+effJRO3P0xmfqyPbSMG0LveNRfTKVg==",
+        "dependencies": {
+          "readable-stream": "readable-stream@1.1.14",
+          "streamsearch": "streamsearch@0.1.2"
+        }
       },
       "ee-first@1.1.1": {
         "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
@@ -594,6 +658,14 @@
         "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
         "dependencies": {}
       },
+      "isarray@0.0.1": {
+        "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+        "dependencies": {}
+      },
+      "isarray@1.0.0": {
+        "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+        "dependencies": {}
+      },
       "media-typer@0.3.0": {
         "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
         "dependencies": {}
@@ -620,6 +692,16 @@
         "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
         "dependencies": {}
       },
+      "minimist@1.2.8": {
+        "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+        "dependencies": {}
+      },
+      "mkdirp@0.5.6": {
+        "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+        "dependencies": {
+          "minimist": "minimist@1.2.8"
+        }
+      },
       "ms@2.0.0": {
         "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
         "dependencies": {}
@@ -627,6 +709,19 @@
       "ms@2.1.3": {
         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
         "dependencies": {}
+      },
+      "multer@1.4.4": {
+        "integrity": "sha512-2wY2+xD4udX612aMqMcB8Ws2Voq6NIUPEtD1be6m411T4uDH/VtL9i//xvcyFlTVfRdaBsk7hV5tgrGQqhuBiw==",
+        "dependencies": {
+          "append-field": "append-field@1.0.0",
+          "busboy": "busboy@0.2.14",
+          "concat-stream": "concat-stream@1.6.2",
+          "mkdirp": "mkdirp@0.5.6",
+          "object-assign": "object-assign@4.1.1",
+          "on-finished": "on-finished@2.4.1",
+          "type-is": "type-is@1.6.18",
+          "xtend": "xtend@4.0.2"
+        }
       },
       "negotiator@0.6.3": {
         "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
@@ -654,6 +749,10 @@
         "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
         "dependencies": {}
       },
+      "process-nextick-args@2.0.1": {
+        "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+        "dependencies": {}
+      },
       "proxy-addr@2.0.7": {
         "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
         "dependencies": {
@@ -679,6 +778,40 @@
           "iconv-lite": "iconv-lite@0.4.24",
           "unpipe": "unpipe@1.0.0"
         }
+      },
+      "raw-body@2.5.2": {
+        "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+        "dependencies": {
+          "bytes": "bytes@3.1.2",
+          "http-errors": "http-errors@2.0.0",
+          "iconv-lite": "iconv-lite@0.4.24",
+          "unpipe": "unpipe@1.0.0"
+        }
+      },
+      "readable-stream@1.1.14": {
+        "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+        "dependencies": {
+          "core-util-is": "core-util-is@1.0.3",
+          "inherits": "inherits@2.0.4",
+          "isarray": "isarray@0.0.1",
+          "string_decoder": "string_decoder@0.10.31"
+        }
+      },
+      "readable-stream@2.3.8": {
+        "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+        "dependencies": {
+          "core-util-is": "core-util-is@1.0.3",
+          "inherits": "inherits@2.0.4",
+          "isarray": "isarray@1.0.0",
+          "process-nextick-args": "process-nextick-args@2.0.1",
+          "safe-buffer": "safe-buffer@5.1.2",
+          "string_decoder": "string_decoder@1.1.1",
+          "util-deprecate": "util-deprecate@1.0.2"
+        }
+      },
+      "safe-buffer@5.1.2": {
+        "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+        "dependencies": {}
       },
       "safe-buffer@5.2.1": {
         "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
@@ -731,6 +864,20 @@
         "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
         "dependencies": {}
       },
+      "streamsearch@0.1.2": {
+        "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
+        "dependencies": {}
+      },
+      "string_decoder@0.10.31": {
+        "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+        "dependencies": {}
+      },
+      "string_decoder@1.1.1": {
+        "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+        "dependencies": {
+          "safe-buffer": "safe-buffer@5.1.2"
+        }
+      },
       "toidentifier@1.0.1": {
         "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
         "dependencies": {}
@@ -742,8 +889,16 @@
           "mime-types": "mime-types@2.1.35"
         }
       },
+      "typedarray@0.0.6": {
+        "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+        "dependencies": {}
+      },
       "unpipe@1.0.0": {
         "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+        "dependencies": {}
+      },
+      "util-deprecate@1.0.2": {
+        "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
         "dependencies": {}
       },
       "utils-merge@1.0.1": {
@@ -752,6 +907,10 @@
       },
       "vary@1.1.2": {
         "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+        "dependencies": {}
+      },
+      "xtend@4.0.2": {
+        "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
         "dependencies": {}
       }
     }

--- a/packages/app-express/deps.ts
+++ b/packages/app-express/deps.ts
@@ -1,7 +1,13 @@
 // See https://deno.land/manual@v1.31.1/advanced/typescript/types#providing-types-when-importing
 // @deno-types="npm:@types/express@^4.17"
 export { default as express } from 'npm:express@4.18.2'
+// @deno-types="npm:@types/multer@^1.4.7"
+export { default as multer } from 'npm:multer@1.4.4'
+// @deno-types="npm:@types/body-parser@^1.19.2"
+export { default as bodyParser } from 'npm:body-parser@1.20.2'
 export { default as cors } from 'npm:cors@2.8.5'
+
+export { readerFromIterable } from 'https://deno.land/std@0.181.0/streams/reader_from_iterable.ts'
 
 /**
  * We will try to use skypack over npm

--- a/packages/app-express/dev_deps.ts
+++ b/packages/app-express/dev_deps.ts
@@ -2,5 +2,5 @@ export {
   assert,
   assertEquals,
   assertObjectMatch,
-} from 'https://deno.land/std@0.180.0/testing/asserts.ts'
+} from 'https://deno.land/std@0.181.0/testing/asserts.ts'
 export { getAvailablePortSync } from 'https://deno.land/x/port@1.0.0/mod.ts'

--- a/packages/app-express/middleware/legacyGet.ts
+++ b/packages/app-express/middleware/legacyGet.ts
@@ -6,3 +6,11 @@ export const legacyGet: RouteHandler = (req, _res, next) => {
   req.isLegacyGetEnabled = isTrue(req.get('X-HYPER-LEGACY-GET'))
   next()
 }
+
+declare global {
+  namespace Express {
+    export interface Request {
+      isLegacyGetEnabled?: boolean
+    }
+  }
+}

--- a/packages/app-express/middleware/object.ts
+++ b/packages/app-express/middleware/object.ts
@@ -1,0 +1,73 @@
+import { multer } from '../deps.ts'
+import type { RouteHandler, UploadedFile } from '../types.ts'
+import { isMultipartFormData, isTrue } from '../utils.ts'
+
+/**
+ * Used when handling multipart/form-data uploads
+ */
+export const formData = multer({ dest: '/tmp/hyper/uploads' }).single('file')
+
+/**
+ * When uploading an object, the object could be provided as:
+ * - multipart/form-data
+ * - raw binary data
+ * - Not provided at all, in which case a signed url is being requested
+ *
+ * This middleware is responsible for determining the intent of the Request
+ * and running it throught the appropriate middleware
+ */
+export const objectBodyParser: RouteHandler = (req, res, next) => {
+  const contentType = req.get('Content-Type')
+  const accept = req.get('Accept')
+
+  /**
+   * The body is multipart/form-data
+   * so parse it as such
+   *
+   * req.body will contain text fields ie. 'path'
+   * if provided
+   */
+  if (isMultipartFormData(contentType)) {
+    req.isMultipartFormData = true
+    return formData(req, res, next)
+  }
+
+  /**
+   * Client is expecting JSON containing a signed url to be returned,
+   * either indicated by:
+   * 1. Accept header being set to application/json
+   * 2. OR useSignedUrl query parameter
+   * 3. OR No Content-Type header being included in the request
+   */
+  if (
+    accept === 'application/json' ||
+    isTrue(req.query?.useSignedUrl) ||
+    !contentType
+  ) {
+    req.useSignedUrl = true
+    return next()
+  }
+
+  /**
+   * Do I need to use raw here?
+   *
+   * If this is turned into a Deno Request Body,
+   * then I should be able to pass the body through
+   * ie. proxy
+   *
+   * https://medium.com/deno-the-complete-reference/handle-file-uploads-in-deno-ee14bd2b16d9#Pass-through-uploaded-file
+   */
+  req.isBinary = true
+  return next()
+}
+
+declare global {
+  namespace Express {
+    export interface Request {
+      useSignedUrl?: boolean
+      isBinary?: boolean
+      isMultipartFormData?: boolean
+      file?: UploadedFile
+    }
+  }
+}

--- a/packages/app-express/test-utils.ts
+++ b/packages/app-express/test-utils.ts
@@ -30,8 +30,8 @@ export const createHarness = (app: Server) => {
     if (!port) return
 
     // Recurse
-    // https://github.com/denoland/deno/issues/13141#issuecomment-997398801
-    if (port === 80 || port === 443) return getUnusedPort()
+    // https://github.com/denoland/deno/issues/17474#issuecomment-1398198358
+    if (port <= 1024) return getUnusedPort()
     if (usedPorts.has(port)) return getUnusedPort()
     usedPorts.add(port)
     return port

--- a/packages/app-express/types.ts
+++ b/packages/app-express/types.ts
@@ -25,9 +25,8 @@ export interface HyperServices {
 
 declare global {
   namespace Express {
-    export interface Request extends HyperServices {
-      isLegacyGetEnabled?: boolean
-    }
+    // deno-lint-ignore no-empty-interface
+    export interface Request extends HyperServices {}
   }
 }
 
@@ -48,3 +47,5 @@ export type ErrorRouteHandler = (
   res: HttpResponse,
   next: express.NextFunction,
 ) => void
+
+export type UploadedFile = Express.Multer.File


### PR DESCRIPTION
This PR implements the `putObject` api on the `app-express` hyper storage api. I used `multer` to handle `multipart/form-data` uploads.

It also implements the ability to accept binary data in the body, using the url path as the object name to pass to core, as described in #571.

Closes #571

I still need to write the unit tests for the middlewares and routes, but wanted to get this PR up before it got too big.

Something that was particularly cool about this implementation:

The app must provide a `Deno.Reader` to hyper core, and since this app is built using `Express` I had to think of a way to convert an Express Request body into a `Deno.Reader` while not losing performance benefits ie. by buffering the body into memory first or something like that. This turned out to be fairly straightforward.

The Express Request object is just an embellished Node `http.IncomingMessage` which is just a `stream.Readable` which in turn is an `AsyncIterable`. Deno provides a stream conversion api that converts an `AsyncIterable` into a Deno.Reader`.

Easy peasy!