### PR TITLE
App Express: getObject and associated tests. `Deno.Reader` -> `ReadableStream`

### DIFF
--- a/packages/app-express/api/storage.test.ts
+++ b/packages/app-express/api/storage.test.ts
@@ -23,6 +23,22 @@ const services: any = {
         name,
         object,
       }),
+    getObject: (_name: any, object: any, useSignedUrl: boolean) => {
+      if (object === 'not_found') {
+        return crocks.Async.Resolved({
+          ok: false,
+          msg: 'not found',
+          status: 404,
+        })
+      }
+      if (useSignedUrl) {
+        return crocks.Async.Resolved({ ok: true, url: 'https://foo.bar' })
+      }
+
+      return crocks.Async.Resolved(
+        new Response('Some awesome object content').body,
+      )
+    },
   },
 }
 
@@ -136,6 +152,118 @@ Deno.test('storage', async (t) => {
           .finally(async () => await harness.stop())
       },
     )
+  })
+
+  await t.step('GET /storage/:name/*', async (t) => {
+    await t.step('Object', async (t) => {
+      await t.step(
+        'should set the Content-Type header according to the extension on the url',
+        async () => {
+          await harness
+            .start()
+            .then(() =>
+              harness('/storage/movies/foo/bar.txt', {
+                method: 'GET',
+              }).then((res) => {
+                assertEquals(
+                  res.headers.get('content-type'),
+                  'text/plain; charset=UTF-8',
+                )
+                return res.body?.cancel()
+              })
+            )
+            .finally(async () => await harness.stop())
+        },
+      )
+
+      await t.step(
+        'should default to application/octet-stream if no mime-type can be derived from the url',
+        async () => {
+          await harness
+            .start()
+            .then(() =>
+              harness('/storage/movies/foo/bar', {
+                method: 'GET',
+              }).then((res) => {
+                assertEquals(
+                  res.headers.get('content-type'),
+                  'application/octet-stream',
+                )
+                return res.body?.cancel()
+              })
+            )
+            .finally(async () => await harness.stop())
+        },
+      )
+
+      await t.step('should stream the data from core', async () => {
+        // no extension
+        await harness
+          .start()
+          .then(() =>
+            harness('/storage/movies/foo/bar', {
+              method: 'GET',
+            })
+              .then((res) => res.text())
+              .then((body) => {
+                assertEquals(body, 'Some awesome object content')
+              })
+          )
+          .finally(async () => await harness.stop())
+
+        // with extension
+        await harness
+          .start()
+          .then(() =>
+            harness('/storage/movies/foo/bar.txt', {
+              method: 'GET',
+            })
+              .then((res) => res.text())
+              .then((body) => {
+                assertEquals(body, 'Some awesome object content')
+              })
+          )
+          .finally(async () => await harness.stop())
+      })
+    })
+
+    await t.step('JSON', async (t) => {
+      await t.step(
+        'should return JSON if a HyperErr comes back from core',
+        async () => {
+          await harness
+            .start()
+            .then(() =>
+              harness('/storage/movies/not_found', {
+                method: 'GET',
+              }).then((res) => {
+                assertEquals(
+                  res.headers.get('content-type'),
+                  'application/json; charset=utf-8',
+                )
+                return res.body?.cancel()
+              })
+            )
+            .finally(async () => await harness.stop())
+        },
+      )
+
+      await t.step(
+        'should set the status to the status in the HyperErr that comes back from core',
+        async () =>
+          await harness
+            .start()
+            .then(() =>
+              harness('/storage/movies/not_found', {
+                method: 'GET',
+              }).then((res) => {
+                assertEquals(res.status, 404)
+                return res.body?.cancel()
+              })
+            )
+            .finally(async () => await harness.stop()),
+      )
+    })
   })
 
   // TODO: add more test coverage here

--- a/packages/app-express/deno.jsonc
+++ b/packages/app-express/deno.jsonc
@@ -1,7 +1,8 @@
 {
   "tasks": {
     "test": "deno lint && deno fmt --check && deno test -A --unstable --no-check",
-    "cache": "deno cache --lock=deno.lock --lock-write deps.ts dev_deps.ts"
+    "cache": "deno cache --lock=deno.lock --lock-write deps.ts dev_deps.ts",
+    "harness": "deno run --no-check --no-lock --unstable -A --reload ./harness.ts"
   },
   "fmt": {
     "files": {

--- a/packages/app-express/deno.lock
+++ b/packages/app-express/deno.lock
@@ -326,16 +326,50 @@
     "https://cdn.skypack.dev/helmet@6.0.1?dts": "61adf27d5338ce683c0226d23bdd646fa3cc46ba7d4ddc5a4db34f3512ec27a8",
     "https://cdn.skypack.dev/ramda@0.28.0": "ac1e3c64a2a3491971bee55f88faeb0923023e903d3ad125f1bd8044b4cad03e",
     "https://cdn.skypack.dev/ramda@0.28.0?dts": "ac1e3c64a2a3491971bee55f88faeb0923023e903d3ad125f1bd8044b4cad03e",
-    "https://deno.land/std@0.181.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.181.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
-    "https://deno.land/std@0.181.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.181.0/io/buffer.ts": "17f4410eaaa60a8a85733e8891349a619eadfbbe42e2f319283ce2b8f29723ab",
-    "https://deno.land/std@0.181.0/streams/reader_from_iterable.ts": "55f68110dce3f8f2c87b834d95f153bc904257fc65175f9f2abe78455cb8047c",
-    "https://deno.land/std@0.181.0/streams/write_all.ts": "aec90152978581ea62d56bb53a5cbf487e6a89c902f87c5969681ffbdf32b998",
-    "https://deno.land/std@0.181.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.181.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.181.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
-    "https://deno.land/std@0.181.0/types.d.ts": "dbaeb2c4d7c526db9828fc8df89d8aecf53b9ced72e0c4568f97ddd8cda616a4",
+    "https://deno.land/std@0.182.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
+    "https://deno.land/std@0.182.0/async/deferred.ts": "42790112f36a75a57db4a96d33974a936deb7b04d25c6084a9fa8a49f135def8",
+    "https://deno.land/std@0.182.0/bytes/bytes_list.ts": "b4cbdfd2c263a13e8a904b12d082f6177ea97d9297274a4be134e989450dfa6a",
+    "https://deno.land/std@0.182.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
+    "https://deno.land/std@0.182.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.182.0/io/buffer.ts": "17f4410eaaa60a8a85733e8891349a619eadfbbe42e2f319283ce2b8f29723ab",
+    "https://deno.land/std@0.182.0/media_types/_db.ts": "7606d83e31f23ce1a7968cbaee852810c2cf477903a095696cdc62eaab7ce570",
+    "https://deno.land/std@0.182.0/media_types/_util.ts": "916efbd30b6148a716f110e67a4db29d6949bf4048997b754415dd7e42c52378",
+    "https://deno.land/std@0.182.0/media_types/content_type.ts": "ad98a5aa2d95f5965b2796072284258710a25e520952376ed432b0937ce743bc",
+    "https://deno.land/std@0.182.0/media_types/extension.ts": "a7cd28c9417143387cdfed27d4e8607ebcf5b1ec27eb8473d5b000144689fe65",
+    "https://deno.land/std@0.182.0/media_types/extensions_by_type.ts": "43806d6a52a0d6d965ada9d20e60a982feb40bc7a82268178d94edb764694fed",
+    "https://deno.land/std@0.182.0/media_types/format_media_type.ts": "f5e1073c05526a6f5a516ac5c5587a1abd043bf1039c71cde1166aa4328c8baf",
+    "https://deno.land/std@0.182.0/media_types/get_charset.ts": "18b88274796fda5d353806bf409eb1d2ddb3f004eb4bd311662c4cdd8ac173db",
+    "https://deno.land/std@0.182.0/media_types/mod.ts": "d3f0b99f85053bc0b98ecc24eaa3546dfa09b856dc0bbaf60d8956d2cdd710c8",
+    "https://deno.land/std@0.182.0/media_types/parse_media_type.ts": "835c4112e1357e95b4f10d7cdea5ae1801967e444f48673ff8f1cb4d32af9920",
+    "https://deno.land/std@0.182.0/media_types/type_by_extension.ts": "daa801eb0f11cdf199445d0f1b656cf116d47dcf9e5b85cc1e6b4469f5ee0432",
+    "https://deno.land/std@0.182.0/media_types/vendor/mime-db.v1.52.0.ts": "6925bbcae81ca37241e3f55908d0505724358cda3384eaea707773b2c7e99586",
+    "https://deno.land/std@0.182.0/streams/_common.ts": "f45cba84f0d813de3326466095539602364a9ba521f804cc758f7a475cda692d",
+    "https://deno.land/std@0.182.0/streams/buffer.ts": "d5b3d7d0299114e5b2ea895a8bf202a687fd915c5282f8096c7bae23b5a04407",
+    "https://deno.land/std@0.182.0/streams/byte_slice_stream.ts": "225d57263a34325d7c96cb3dafeb478eec0e6fd05cd0458d678752eadd132bb4",
+    "https://deno.land/std@0.182.0/streams/copy.ts": "75cbc795ff89291df22ddca5252de88b2e16d40c85d02840593386a8a1454f71",
+    "https://deno.land/std@0.182.0/streams/delimiter_stream.ts": "f69e849b3d1f59f02424497273f411105a6f76a9f13da92aeeb9a2d554236814",
+    "https://deno.land/std@0.182.0/streams/early_zip_readable_streams.ts": "4005fa74162b943f79899e5d7cb96adcbc0a6b867f9144974ed12d30e0a556e1",
+    "https://deno.land/std@0.182.0/streams/iterate_reader.ts": "bbec1d45c2df2c0c5920bad0549351446fdc8e0886d99e95959b259dbcdb6072",
+    "https://deno.land/std@0.182.0/streams/limited_bytes_transform_stream.ts": "05dc592ffaab83257494d22dd53917e56243c26e5e3129b3f13ddbbbc4785048",
+    "https://deno.land/std@0.182.0/streams/limited_transform_stream.ts": "d69ab790232c1b86f53621ad41ef03c235f2abb4b7a1cd51960ad6e12ee55e38",
+    "https://deno.land/std@0.182.0/streams/merge_readable_streams.ts": "5d6302888f4bb0616dafb5768771be0aec9bedc05fbae6b3d726d05ffbec5b15",
+    "https://deno.land/std@0.182.0/streams/mod.ts": "c07ec010e700b9ea887dc36ca08729828bc7912f711e4054e24d33fd46282252",
+    "https://deno.land/std@0.182.0/streams/read_all.ts": "ee319772fb0fd28302f97343cc48dfcf948f154fd0d755d8efe65814b70533be",
+    "https://deno.land/std@0.182.0/streams/readable_stream_from_iterable.ts": "cd4bb9e9bf6dbe84c213beb1f5085c326624421671473e410cfaecad15f01865",
+    "https://deno.land/std@0.182.0/streams/readable_stream_from_reader.ts": "bfc416c4576a30aac6b9af22c9dc292c20c6742141ee7c55b5e85460beb0c54e",
+    "https://deno.land/std@0.182.0/streams/reader_from_iterable.ts": "55f68110dce3f8f2c87b834d95f153bc904257fc65175f9f2abe78455cb8047c",
+    "https://deno.land/std@0.182.0/streams/reader_from_stream_reader.ts": "fa4971e5615a010e49492c5d1688ca1a4d17472a41e98b498ab89a64ebd7ac73",
+    "https://deno.land/std@0.182.0/streams/text_delimiter_stream.ts": "20e680ab8b751390e359288ce764f9c47d164af11a263870746eeca4bc7d976b",
+    "https://deno.land/std@0.182.0/streams/text_line_stream.ts": "0f2c4b33a5fdb2476f2e060974cba1347cefe99a4af33c28a57524b1a34750fa",
+    "https://deno.land/std@0.182.0/streams/to_transform_stream.ts": "7f55fc0b14cf3ed0f8d10d8f41d05bdc40726e44a65c37f58705d10a615f0159",
+    "https://deno.land/std@0.182.0/streams/writable_stream_from_writer.ts": "56fff5c82fb736fdd669b567cc0b2bbbe0351002cd13254eae26c366e2bed89a",
+    "https://deno.land/std@0.182.0/streams/write_all.ts": "aec90152978581ea62d56bb53a5cbf487e6a89c902f87c5969681ffbdf32b998",
+    "https://deno.land/std@0.182.0/streams/writer_from_stream_writer.ts": "07c7ee025151a190f37fc42cbb01ff93afc949119ebddc6e0d0df14df1bf6950",
+    "https://deno.land/std@0.182.0/streams/zip_readable_streams.ts": "a9d81aa451240f79230add674809dbee038d93aabe286e2d9671e66591fc86ca",
+    "https://deno.land/std@0.182.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.182.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.182.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
+    "https://deno.land/std@0.182.0/types.d.ts": "dbaeb2c4d7c526db9828fc8df89d8aecf53b9ced72e0c4568f97ddd8cda616a4",
     "https://deno.land/x/port@1.0.0/mod.ts": "2dc04ce1ccf133ae09205e30b550044c4c6f64a1a7d00ea91c66dbb9f6cc00f5",
     "https://deno.land/x/port@1.0.0/types.ts": "42d6ae4147d5d67408d60209da070ddfa79ec8389c6cab1b8002df0cf6c03af6",
     "https://nh4m2oo3u2uzqx2uyiruod74pqtbtiphcid2l3i4mzutjvinek7q.arweave.net/afjNOdumqZhfVMIjRw_8fCYZoecSB6XtHGZpNNUNIr8/hyper-err.js": "434ce4bd1cc58e220aad95148bfb04ad7c43738cb5f771a02a45ea8608ac71cc"
@@ -355,19 +389,19 @@
         "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
         "dependencies": {
           "@types/connect": "@types/connect@3.4.35",
-          "@types/node": "@types/node@18.15.7"
+          "@types/node": "@types/node@18.15.11"
         }
       },
       "@types/connect@3.4.35": {
         "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
         "dependencies": {
-          "@types/node": "@types/node@18.15.7"
+          "@types/node": "@types/node@18.15.11"
         }
       },
       "@types/express-serve-static-core@4.17.33": {
         "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
         "dependencies": {
-          "@types/node": "@types/node@18.15.7",
+          "@types/node": "@types/node@18.15.11",
           "@types/qs": "@types/qs@6.9.7",
           "@types/range-parser": "@types/range-parser@1.2.4"
         }
@@ -391,8 +425,8 @@
           "@types/express": "@types/express@4.17.17"
         }
       },
-      "@types/node@18.15.7": {
-        "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA==",
+      "@types/node@18.15.11": {
+        "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
         "dependencies": {}
       },
       "@types/qs@6.9.7": {
@@ -407,7 +441,7 @@
         "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
         "dependencies": {
           "@types/mime": "@types/mime@3.0.1",
-          "@types/node": "@types/node@18.15.7"
+          "@types/node": "@types/node@18.15.11"
         }
       },
       "accepts@1.3.8": {

--- a/packages/app-express/deps.ts
+++ b/packages/app-express/deps.ts
@@ -7,7 +7,8 @@ export { default as multer } from 'npm:multer@1.4.4'
 export { default as bodyParser } from 'npm:body-parser@1.20.2'
 export { default as cors } from 'npm:cors@2.8.5'
 
-export { readerFromIterable } from 'https://deno.land/std@0.181.0/streams/reader_from_iterable.ts'
+export { readableStreamFromIterable } from 'https://deno.land/std@0.182.0/streams/mod.ts'
+export { contentType as getMimeType } from 'https://deno.land/std@0.182.0/media_types/mod.ts'
 
 /**
  * We will try to use skypack over npm

--- a/packages/app-express/dev_deps.ts
+++ b/packages/app-express/dev_deps.ts
@@ -2,5 +2,6 @@ export {
   assert,
   assertEquals,
   assertObjectMatch,
-} from 'https://deno.land/std@0.181.0/testing/asserts.ts'
+} from 'https://deno.land/std@0.182.0/testing/asserts.ts'
+export { Buffer } from 'https://deno.land/std@0.182.0/io/buffer.ts'
 export { getAvailablePortSync } from 'https://deno.land/x/port@1.0.0/mod.ts'

--- a/packages/app-express/harness.ts
+++ b/packages/app-express/harness.ts
@@ -1,0 +1,14 @@
+// Load .env
+import 'https://deno.land/std@0.182.0/dotenv/load.ts'
+
+import { default as core } from 'https://x.nest.land/hyper@3.4.2/mod.js'
+import namespacedS3 from 'https://x.nest.land/hyper-adapter-namespaced-s3@3.0.0/mod.js'
+
+import app from './mod.ts'
+
+const hyperConfig = {
+  app,
+  adapters: [{ port: 'storage', plugins: [namespacedS3('express-harness')] }],
+}
+
+core(hyperConfig)


### PR DESCRIPTION
Closes #554

Also made it such that `putObject` expects to pass a `ReadableStream` to `core`. Which makes streaming requests into core much simpler and performant.

What's left is to beef up tests on the driving app-express adapter and it is done 🎊 