### PR TITLE
Version hyper-nano binaries and place artifacts in the current working directory

### DIFF
--- a/.github/workflows/image-nano.yml
+++ b/.github/workflows/image-nano.yml
@@ -56,6 +56,9 @@ jobs:
       - name: 🛠 Build Executables
         run: |
          cd images/nano
+
+         export VER=$(node -e "console.log(require('./package.json').version)")
+         echo "binary version: $VER"
          make clean compile-linux compile-apple compile-arch-apple compile-windows
         env:
           CI: true
@@ -70,8 +73,10 @@ jobs:
       - name: 🗄 Upload Executables to S3
         run: |
           cd images/nano
-          echo "aliasing linux binary to 'hyper'"
-          cp ./build/hyper-x86_64-unknown-linux-gnu ./build/hyper
+          echo "aliasing latest linux binary to 'hyper'"
+          export VER=$(node -e "console.log(require('./package.json').version)")
+          echo "binary version: $VER"
+          cp ./build/hyper-x86_64-unknown-linux-gnu-$VER ./build/hyper
           echo "copying binaries to hyperland s3 ⚡️"
           aws s3 cp --acl public-read --recursive ./build s3://hyperland
 

--- a/images/nano/Makefile
+++ b/images/nano/Makefile
@@ -2,13 +2,25 @@ clean:
 	@rm -rf ./build
 
 compile-linux:
-	@deno compile --target=x86_64-unknown-linux-gnu --allow-sys --allow-env --allow-read --allow-write=__hyper__,/tmp/hyper --allow-net --unstable --no-check=remote --output ./build/hyper-x86_64-unknown-linux-gnu mod.js
+	@deno compile --target=x86_64-unknown-linux-gnu \
+	--allow-sys --allow-env --allow-read --allow-write=__hyper__ --allow-net \
+	--unstable --no-check=remote \
+	--output ./build/hyper-x86_64-unknown-linux-gnu-$(VER) mod.js
 
 compile-apple:
-	@deno compile --target=x86_64-apple-darwin --allow-sys --allow-env --allow-read --allow-write=__hyper__,/tmp/hyper --allow-net --unstable --no-check=remote --output ./build/hyper-x86_64-apple-darwin mod.js
+	@deno compile --target=x86_64-apple-darwin \
+	--allow-sys --allow-env --allow-read --allow-write=__hyper__ --allow-net \
+	--unstable --no-check=remote \
+	--output ./build/hyper-x86_64-apple-darwin-$(VER) mod.js
 
 compile-arch-apple:
-	@deno compile --target=aarch64-apple-darwin --allow-sys --allow-env --allow-read --allow-write=__hyper__,/tmp/hyper --allow-net --unstable --no-check=remote --output ./build/hyper-aarch64-apple-darwin mod.js
+	@deno compile --target=aarch64-apple-darwin \
+	--allow-sys --allow-env --allow-read --allow-write=__hyper__ --allow-net \
+	--unstable --no-check=remote \
+	--output ./build/hyper-aarch64-apple-darwin-$(VER) mod.js
 
 compile-windows:
-	@deno compile --target=x86_64-pc-windows-msvc --allow-sys --allow-env --allow-read --allow-write=__hyper__,/tmp/hyper --allow-net --unstable --no-check=remote --output ./build/hyper-x86_64-pc-windows-msvc mod.js
+	@deno compile --target=x86_64-pc-windows-msvc \
+	--allow-sys --allow-env --allow-read --allow-write=__hyper__ --allow-net \
+	--unstable --no-check=remote \
+	--output ./build/hyper-x86_64-pc-windows-msvc-$(VER) mod.js

--- a/images/nano/bin/index.js
+++ b/images/nano/bin/index.js
@@ -8,7 +8,7 @@ const { dirname, join } = require('path')
 const chalk = require('chalk')
 const ora = require('ora')
 
-const destDir = join(dirname(__filename))
+const destDir = join(dirname('.'))
 const binaryDest = join(destDir, 'hyper-nano')
 
 function getBinary() {

--- a/images/nano/bin/index.js
+++ b/images/nano/bin/index.js
@@ -8,15 +8,17 @@ const { dirname, join } = require('path')
 const chalk = require('chalk')
 const ora = require('ora')
 
+const { version } = require('../package.json')
+
 const destDir = join(dirname('.'))
 const binaryDest = join(destDir, 'hyper-nano')
 
 function getBinary() {
   const binaries = {
-    linux: 'hyper-x86_64-unknown-linux-gnu',
-    win32: 'hyper-x86_64-pc-windows-msvc.exe',
-    darwinx86_64: 'hyper-x86_64-apple-darwin',
-    darwinarm64: 'hyper-aarch64-apple-darwin',
+    linux: `hyper-x86_64-unknown-linux-gnu-${version}`,
+    win32: `hyper-x86_64-pc-windows-msvc-${version}.exe`,
+    darwinx86_64: `hyper-x86_64-apple-darwin-${version}`,
+    darwinarm64: `hyper-aarch64-apple-darwin-${version}`,
   }
 
   const os = platform()

--- a/images/nano/deno.lock
+++ b/images/nano/deno.lock
@@ -671,10 +671,10 @@
     "https://cdn.skypack.dev/minisearch@^4": "3c5b2945034f1997842b0dbc9cee0bcf4659cc6e2a66e038dd3eaec3dd574b76",
     "https://cdn.skypack.dev/pin/indexeddbshim@v9.0.0-QVaW8rBIOGlJegwkWTsK/mode=imports/unoptimized/dist/indexeddbshim-noninvasive.js": "978a698ccf50ce19735b1da6cad00277cc8fc790610df183c61c2f9cc1df9c9b",
     "https://cdn.skypack.dev/pin/pouchdb-adapter-http@v7.3.0-wNzBHi1B5WLNzMPlTnWb/mode=imports/optimized/pouchdb-adapter-http.js": "023e92d130094b0e43638ee849b5b4f539fd987034104452c933fcd505a96242",
-    "https://cdn.skypack.dev/pin/pouchdb-adapter-idb@v7.3.0-zIdGq675NuTdgkAjGFSh/mode=imports/optimized/pouchdb-adapter-idb.js": "76bd6a4758f5c20caa03cba2b52a7345d5d724393bda93b82131342461d300d4",
+    "https://cdn.skypack.dev/pin/pouchdb-adapter-idb@v7.3.0-zIdGq675NuTdgkAjGFSh/mode=imports/optimized/pouchdb-adapter-idb.js": "978861200eebec820bcadab143d6712d8ce481ee73e579f2aedea050e23b3ef2",
     "https://cdn.skypack.dev/pin/pouchdb-core@v7.3.0-89HuCNEcWBT7jv1msAf2/mode=imports/optimized/pouchdb-core.js": "66ab654df46ef713bc9822010e2a9be5caa974ece65a88f72e10951836da3b99",
-    "https://cdn.skypack.dev/pin/pouchdb-mapreduce@v7.3.0-IEG2Gq1jfS0hW8QXVXqd/mode=imports/optimized/pouchdb-mapreduce.js": "be7fbbcd6a9fcd6ac6be2b4a5f0bef02fc84618cfbd6ec3cafd1d1a288e459e9",
-    "https://cdn.skypack.dev/pin/pouchdb-replication@v7.3.0-1sg1NWcwDf6gKFeXsMmq/mode=imports/optimized/pouchdb-replication.js": "474a0861108abb668cba6d1897a6ad947eb3573a7ee75875e501d6988ec0dfa6",
+    "https://cdn.skypack.dev/pin/pouchdb-mapreduce@v7.3.0-IEG2Gq1jfS0hW8QXVXqd/mode=imports/optimized/pouchdb-mapreduce.js": "e6d57d046d89e21e2102bee9e25612e2bf7209b707176dcc7cabc0a563d61acb",
+    "https://cdn.skypack.dev/pin/pouchdb-replication@v7.3.0-1sg1NWcwDf6gKFeXsMmq/mode=imports/optimized/pouchdb-replication.js": "79cdcfeefc7ac944e1cd1f80de270b1f8b78a4d7eafc4076902526c3255d2a25",
     "https://cdn.skypack.dev/pin/pouchdb@v7.3.0-bcA2ZAvx5a5vy7YRYZRz/mode=imports/unoptimized/dist/pouchdb.find.js": "4f5bd824948b2f07970da663ac2a07231595bef8ce8ecf66856094d222c03945",
     "https://cdn.skypack.dev/pin/pouchdb@v7.3.0-bcA2ZAvx5a5vy7YRYZRz/mode=imports/unoptimized/dist/pouchdb.indexeddb.js": "1a9824ca9abdaa3e1bae6fb2922d9c67d66f255cdb2d26b094f882875e734c3d",
     "https://cdn.skypack.dev/pin/pouchdb@v7.3.0-bcA2ZAvx5a5vy7YRYZRz/mode=imports/unoptimized/dist/pouchdb.memory.js": "70224a97fd91fa337915585734d170758bcad711ce4cc04e7621489d3333d775",
@@ -974,8 +974,8 @@
       "multer@1.4.4": "multer@1.4.4"
     },
     "packages": {
-      "@babel/runtime@7.21.5": {
-        "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "@babel/runtime@7.22.3": {
+        "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
         "dependencies": {
           "regenerator-runtime": "regenerator-runtime@0.13.11"
         }
@@ -984,19 +984,19 @@
         "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
         "dependencies": {
           "@types/connect": "@types/connect@3.4.35",
-          "@types/node": "@types/node@20.2.1"
+          "@types/node": "@types/node@20.2.5"
         }
       },
       "@types/connect@3.4.35": {
         "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
         "dependencies": {
-          "@types/node": "@types/node@20.2.1"
+          "@types/node": "@types/node@20.2.5"
         }
       },
       "@types/express-serve-static-core@4.17.35": {
         "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
         "dependencies": {
-          "@types/node": "@types/node@20.2.1",
+          "@types/node": "@types/node@20.2.5",
           "@types/qs": "@types/qs@6.9.7",
           "@types/range-parser": "@types/range-parser@1.2.4",
           "@types/send": "@types/send@0.17.1"
@@ -1025,8 +1025,8 @@
           "@types/express": "@types/express@4.17.17"
         }
       },
-      "@types/node@20.2.1": {
-        "integrity": "sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==",
+      "@types/node@20.2.5": {
+        "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
         "dependencies": {}
       },
       "@types/qs@6.9.7": {
@@ -1041,14 +1041,14 @@
         "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
         "dependencies": {
           "@types/mime": "@types/mime@1.3.2",
-          "@types/node": "@types/node@20.2.1"
+          "@types/node": "@types/node@20.2.5"
         }
       },
       "@types/serve-static@1.15.1": {
         "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
         "dependencies": {
           "@types/mime": "@types/mime@3.0.1",
-          "@types/node": "@types/node@20.2.1"
+          "@types/node": "@types/node@20.2.5"
         }
       },
       "accepts@1.3.8": {
@@ -1163,7 +1163,7 @@
       "date-fns@2.30.0": {
         "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
         "dependencies": {
-          "@babel/runtime": "@babel/runtime@7.21.5"
+          "@babel/runtime": "@babel/runtime@7.22.3"
         }
       },
       "debug@2.6.9": {


### PR DESCRIPTION
BREAKING CHANGE

closes #537 

This PR changes `hyper-nano` on Node to download the hyper-binary into the current working directory, which is to say wherever `npx` is ran from, typically the project directory. This is similar behavior to tools like the NextJS CLI when running `next build`.

With this, installing dependencies with `yarn` will not blow away the binary and any persisted data in the `__hyper__` directory, as described in #537 

This is breaking change, since users will need to add the `hyper-nano` binary and the `__hyper__` directory to their `.gitignore`.

---

This PR also makes new versions of `hyper-nano` be published to our S3 bucket with a version suffix. This way, each `hyper-nano` version has a corresponding binary version to be downloaded from S3.