### PR TITLE
feat(port-data): add partialFilter option to indexDocuments

### DIFF
--- a/packages/port-data/mod.test.ts
+++ b/packages/port-data/mod.test.ts
@@ -644,6 +644,17 @@ Deno.test('data', async (t) => {
         }),
       )
 
+      assert(
+        await adapter.indexDocuments({
+          db: 'foo',
+          fields: [{ name: 'ASC' }, { foo: 'ASC' }],
+          name: 'idx-name',
+          partialFilter: {
+            type: 'user',
+          },
+        }),
+      )
+
       await assertRejects(() =>
         adapter.indexDocuments({
           db: 'foo',
@@ -666,6 +677,16 @@ Deno.test('data', async (t) => {
       await assertRejects(() =>
         // @ts-ignore
         adapter.indexDocuments({ db: 'foo', fields: ['name'], name: 123 })
+      )
+
+      await assertRejects(() =>
+        // @ts-ignore
+        adapter.indexDocuments({
+          db: 'foo',
+          fields: ['name'],
+          name: 'idx-name',
+          partialFilter: 123,
+        })
       )
     })
 

--- a/packages/port-data/port.ts
+++ b/packages/port-data/port.ts
@@ -123,6 +123,7 @@ export const port = z.object({
         db: z.string(),
         name: z.string(),
         fields: z.union([z.array(z.string()), z.array(z.record(SortEnum))]),
+        partialFilter: z.record(z.any()).optional(),
       }),
     )
     .returns(z.promise(hyperResponse({}))),


### PR DESCRIPTION
Adds the ability to pass a filter, when creating an index on documents in a hyper data service. Documents are only included in the index, if they match the filter associated with the index.

This is common feature across document databases that reduces index storage usage and index performance ie. [Couch](https://docs.couchdb.org/en/stable/api/database/find.html#partial-indexes), and [Mongo](https://www.mongodb.com/docs/manual/core/index-partial/#partial-indexes) 