### PR TITLE
Require confirmation on hyper.*.destroy on `hyper-connect`

### DIFF
--- a/packages/connect/deno/mod.ts
+++ b/packages/connect/deno/mod.ts
@@ -214,6 +214,16 @@ export function connect(CONNECTION_STRING: string, domain = 'default'): Hyper {
           .then(storage.remove(name))
           .then($fetch)
           .then(handleResponse),
+      create: () =>
+        Promise.resolve(h)
+          .then(storage.create())
+          .then($fetch)
+          .then(handleResponse),
+      destroy: (confirm) =>
+        Promise.resolve(h)
+          .then(storage.destroy(confirm))
+          .then($fetch)
+          .then(handleResponse),
     },
     queue: {
       enqueue: (job) =>

--- a/packages/connect/deno/services/cache.ts
+++ b/packages/connect/deno/services/cache.ts
@@ -46,7 +46,7 @@ export const query = (pattern = '*') => (h: HyperRequestFunction) =>
 
 export const create = () => (hyper: HyperRequestFunction) => hyper({ service, method: Method.PUT })
 
-export const destroy = (confirm = true) => (hyper: HyperRequestFunction) =>
+export const destroy = (confirm?: boolean) => (hyper: HyperRequestFunction) =>
   confirm
     ? hyper({ service, method: Method.DELETE })
     : Promise.reject({ ok: false, msg: 'request not confirmed!' })

--- a/packages/connect/deno/services/data.ts
+++ b/packages/connect/deno/services/data.ts
@@ -65,7 +65,7 @@ export const index = (
 
 export const create = () => (hyper: HyperRequestFunction) => hyper({ service, method: Method.PUT })
 
-export const destroy = (confirm = true) => (hyper: HyperRequestFunction) =>
+export const destroy = (confirm?: boolean) => (hyper: HyperRequestFunction) =>
   confirm
     ? hyper({ service, method: Method.DELETE })
     : Promise.reject({ ok: false, msg: 'request not confirmed!' })

--- a/packages/connect/deno/services/search.ts
+++ b/packages/connect/deno/services/search.ts
@@ -36,7 +36,7 @@ export const load = (docs: unknown[]) => (hyper: HyperRequestFunction) =>
 export const create = (fields: string[], storeFields?: string[]) => (hyper: HyperRequestFunction) =>
   hyper({ service, method: Method.PUT, body: { fields, storeFields } })
 
-export const destroy = (confirm = true) => (hyper: HyperRequestFunction) =>
+export const destroy = (confirm?: boolean) => (hyper: HyperRequestFunction) =>
   confirm
     ? hyper({ service, method: Method.DELETE })
     : Promise.reject({ ok: false, msg: 'request not confirmed!' })

--- a/packages/connect/deno/services/storage.ts
+++ b/packages/connect/deno/services/storage.ts
@@ -63,3 +63,10 @@ export const signedUrl =
 
 export const remove = (name: string) => (h: HyperRequestFunction) =>
   h({ service, method: Method.DELETE, resource: name })
+
+export const create = () => (hyper: HyperRequestFunction) => hyper({ service, method: Method.PUT })
+
+export const destroy = (confirm?: boolean) => (hyper: HyperRequestFunction) =>
+  confirm
+    ? hyper({ service, method: Method.DELETE })
+    : Promise.reject({ ok: false, msg: 'request not confirmed!' })

--- a/packages/connect/deno/tests/cache.test.ts
+++ b/packages/connect/deno/tests/cache.test.ts
@@ -1,5 +1,5 @@
 import { HyperRequest } from '../types.ts'
-import { assertEquals } from '../dev_deps.ts'
+import { assert, assertEquals } from '../dev_deps.ts'
 
 import { add, create, destroy, get, query, remove, set } from '../services/cache.ts'
 import { HYPER_LEGACY_GET_HEADER } from '../utils/hyper-request.ts'
@@ -96,4 +96,10 @@ test('cache.destroy', async () => {
   }
 
   await destroy(true)(mockRequest)
+
+  const noConfirmRequest = (_h: HyperRequest) => {
+    assert(false, 'unreachable')
+  }
+
+  await destroy()(noConfirmRequest).catch(assert)
 })

--- a/packages/connect/deno/tests/data.test.ts
+++ b/packages/connect/deno/tests/data.test.ts
@@ -1,6 +1,6 @@
 import { HyperRequest } from '../types.ts'
 
-import { assertEquals } from '../dev_deps.ts'
+import { assert, assertEquals } from '../dev_deps.ts'
 
 import { add, bulk, create, destroy, get, index, query, remove, update } from '../services/data.ts'
 import { HYPER_LEGACY_GET_HEADER } from '../utils/hyper-request.ts'
@@ -154,4 +154,10 @@ test('data.destroy', async () => {
   }
 
   await destroy(true)(mockRequest)
+
+  const noConfirmRequest = (_h: HyperRequest) => {
+    assert(false, 'unreachable')
+  }
+
+  await destroy()(noConfirmRequest).catch(assert)
 })

--- a/packages/connect/deno/tests/search.test.ts
+++ b/packages/connect/deno/tests/search.test.ts
@@ -1,6 +1,6 @@
 import { HyperRequest } from '../types.ts'
 
-import { assertEquals } from '../dev_deps.ts'
+import { assert, assertEquals } from '../dev_deps.ts'
 
 import { add, create, destroy, get, load, query, remove, update } from '../services/search.ts'
 
@@ -127,4 +127,10 @@ test('search.destroy', async () => {
   }
 
   await destroy(true)(mockRequest)
+
+  const noConfirmRequest = (_h: HyperRequest) => {
+    assert(false, 'unreachable')
+  }
+
+  await destroy()(noConfirmRequest).catch(assert)
 })

--- a/packages/connect/deno/tests/storage.test.ts
+++ b/packages/connect/deno/tests/storage.test.ts
@@ -1,7 +1,7 @@
 import { HyperRequest } from '../types.ts'
-import { assertEquals } from '../dev_deps.ts'
+import { assert, assertEquals } from '../dev_deps.ts'
 
-import { download, remove, signedUrl, upload } from '../services/storage.ts'
+import { create, destroy, download, remove, signedUrl, upload } from '../services/storage.ts'
 
 const test = Deno.test
 
@@ -98,4 +98,32 @@ test('storage.remove', async () => {
   }
   const req = await remove('avatar.png')(mockRequest)
   assertEquals(req.url, 'http://localhost/storage/bucket/avatar.png')
+})
+
+test('storage.create', async () => {
+  const mockRequest = (h: HyperRequest) => {
+    assertEquals(h.service, 'storage')
+    assertEquals(h.method, 'PUT')
+    return Promise.resolve(new Request('http://localhost', { method: 'PUT' }))
+  }
+
+  await create()(mockRequest)
+})
+
+test('storage.destroy', async () => {
+  const mockRequest = (h: HyperRequest) => {
+    assertEquals(h.service, 'storage')
+    assertEquals(h.method, 'DELETE')
+    return Promise.resolve(
+      new Request('http://localhost', { method: 'DELETE' }),
+    )
+  }
+
+  await destroy(true)(mockRequest)
+
+  const noConfirmRequest = (_h: HyperRequest) => {
+    assert(false, 'unreachable')
+  }
+
+  await destroy()(noConfirmRequest).catch(assert)
 })

--- a/packages/connect/deno/types.ts
+++ b/packages/connect/deno/types.ts
@@ -164,6 +164,8 @@ export interface HyperStorage {
     options: StorageSignedUrlOptions,
   ) => Promise<OkUrlResult | NotOkResult>
   remove: (name: string) => Promise<Result>
+  create: () => Promise<IdResult>
+  destroy: (confirm: boolean) => Promise<Result>
 }
 
 export interface HyperQueue {


### PR DESCRIPTION
Also exposed `create` and `destroy` on `storage`