### PR TITLE
chore(connect): remove duplex option except for storage.upload

### DIFF
--- a/packages/connect/deno/utils/hyper-request.ts
+++ b/packages/connect/deno/utils/hyper-request.ts
@@ -38,7 +38,9 @@ export const fetchWithShim = (f: typeof fetch) =>
      * duplex needed for node
      * See https://github.com/nodejs/node/issues/46221
      */
-    ...(req.body ? { body: req.body, duplex: 'half' } : {}),
+    // deno-lint-ignore ban-ts-comment
+    // @ts-ignore
+    ...(req.body ? { body: req.body, duplex: true } : {}),
   })
 
 export const hyper = (conn: URL, domain: string) =>


### PR DESCRIPTION
This is really only needed when the `body` is a `ReadableStream` or `AsyncIterable`, which is only the case for `storage.upload`, which does set that itself.

So this can be removed.